### PR TITLE
Feature/api/validators tests role permission

### DIFF
--- a/packages/api/app/Validators/StorePermission.js
+++ b/packages/api/app/Validators/StorePermission.js
@@ -1,0 +1,12 @@
+const BaseValidator = use('App/Validators/BaseValidator');
+
+class StorePermission extends BaseValidator {
+	get rules() {
+		return {
+			permission: 'required|unique:permissions',
+			description: 'required',
+		};
+	}
+}
+
+module.exports = StorePermission;

--- a/packages/api/app/Validators/StoreRole.js
+++ b/packages/api/app/Validators/StoreRole.js
@@ -1,0 +1,12 @@
+const BaseValidator = use('App/Validators/BaseValidator');
+
+class StoreRole extends BaseValidator {
+	get rules() {
+		return {
+			role: 'required|unique:roles',
+			description: 'required',
+		};
+	}
+}
+
+module.exports = StoreRole;

--- a/packages/api/app/Validators/UpdatePermission.js
+++ b/packages/api/app/Validators/UpdatePermission.js
@@ -1,0 +1,11 @@
+const BaseValidator = use('App/Validators/BaseValidator');
+
+class UpdatePermission extends BaseValidator {
+	get rules() {
+		return {
+			permission: 'unique:permissions',
+		};
+	}
+}
+
+module.exports = UpdatePermission;

--- a/packages/api/app/Validators/UpdateRole.js
+++ b/packages/api/app/Validators/UpdateRole.js
@@ -1,0 +1,11 @@
+const BaseValidator = use('App/Validators/BaseValidator');
+
+class UpdateRole extends BaseValidator {
+	get rules() {
+		return {
+			role: 'unique:roles',
+		};
+	}
+}
+
+module.exports = UpdateRole;

--- a/packages/api/database/migrations/1588000294678_alter_permission_unique_schema.js
+++ b/packages/api/database/migrations/1588000294678_alter_permission_unique_schema.js
@@ -1,0 +1,20 @@
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema');
+
+class AlterPermissionUniqueSchema extends Schema {
+	up() {
+		this.table('permissions', (table) => {
+			// alter table
+			table.unique('permission');
+		});
+	}
+
+	down() {
+		this.table('permissions', (table) => {
+			// reverse alternations
+			table.dropUnique('permission');
+		});
+	}
+}
+
+module.exports = AlterPermissionUniqueSchema;

--- a/packages/api/database/migrations/1588003358199_alter_role_unique_schema.js
+++ b/packages/api/database/migrations/1588003358199_alter_role_unique_schema.js
@@ -1,0 +1,18 @@
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema');
+
+class AlterRoleUniqueSchema extends Schema {
+	up() {
+		this.table('roles', (table) => {
+			table.unique('role');
+		});
+	}
+
+	down() {
+		this.table('roles', (table) => {
+			table.dropUnique('role');
+		});
+	}
+}
+
+module.exports = AlterRoleUniqueSchema;

--- a/packages/api/start/routes.js
+++ b/packages/api/start/routes.js
@@ -19,9 +19,22 @@ Route.get('/auth/forgot-password', 'AuthController.forgotPassword').validator('F
 Route.post('/auth/reset-password', 'AuthController.resetPassword').validator('ResetPassword');
 
 Route.resource('roles', 'RoleController')
+	.validator(
+		new Map([
+			[['roles.store'], ['StoreRole']],
+			[['roles.update'], ['UpdateRole']],
+		]),
+	)
 	.apiOnly()
 	.middleware('auth');
+
 Route.resource('permissions', 'PermissionController')
+	.validator(
+		new Map([
+			[['permissions.store'], ['StorePermission']],
+			[['permissions.update'], ['UpdatePermission']],
+		]),
+	)
 	.apiOnly()
 	.middleware('auth');
 


### PR DESCRIPTION
## Summary

Addresses issue #69

## Relevant technical choices

Essa PR contempla os validadores do cadastro e atualização dos esquemas Papel e Permissão.
Os seguintes validadores foram criados:
StorePermission: Valida o cadastro de uma nova permissão.
Os campos permission e description são obrigatórios
UpdatePermission: Valida a atualização de uma nova permissão.
Caso a atualização tente alterar o campo permission para um já existente cai na validação unique
StoreRole: Valida o cadastro de um novo papel.
Os campos role e description são obrigatórios
UpdateRole: Valida a atualização de um novo papel.
Caso a atualização tente alterar o campo role para um já existente cai na validação unique

Foram criadas duas migrations para tornar os campos permission e role unique,não tinha sido feito no inicio:
AlterPermissionUniqueSchema
AlterRoleUniqueSchema

## QA Steps

Para testar essa PR basta executar as migrations novas e os testes funcionais: Especificamente:

Em permission.spec.js:
POST /permissions endpoint fails when sending invalid payload
POST /permissions endpoint fails when sending existent permission
PUT /permissions/:id endpoint fails when trying update with same permission name

Em role.spec.js
POST /roles endpoint fails when sending invalid payload
POST /roles endpoint fails when sending existent role
PUT /roles/:id endpoint fails when trying update with same role name


## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.