### PR TITLE
Fix/web/deploy

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -10308,22 +10308,22 @@
       }
     },
     "i18next-fs-backend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-1.0.1.tgz",
-      "integrity": "sha512-Ek+I44Ijrfcpqfd+LtNB4l+hw1Vt7zAPyzpHcXjFNr+02zL/fh/ue07cQEbRfsZyvwGNJ+soCSPW3OwfFHRLpQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-1.0.2.tgz",
+      "integrity": "sha512-7N7V6gu00/UBdCjz37JFKGB5UfuLDJlIoLMAxXQG5ih3CFKPqtJ7GfQ7lqd8t/L/6EQ1sciZ9022Xy5BwTrf7g=="
     },
     "i18next-http-backend": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-1.0.7.tgz",
-      "integrity": "sha512-/SoLKvNm3Pm8vl1Y5zgHFsbBAEmEdn/bZoMNasGl+3wFI2zKgagevyhaCxC3m3IO3oHsgk2k77PE6aNnfKE0Kg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-1.0.8.tgz",
+      "integrity": "sha512-f9oWlt3AuMh+xuKVpG8qlP6azI40N+wRBK/2jaJ7tHk6vMJSAGtZSM76Zx7p2JULqj27yNnc2yOEN4moq3RuFg==",
       "requires": {
         "node-fetch": "2.6.0"
       }
     },
     "i18next-http-middleware": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-1.0.0.tgz",
-      "integrity": "sha512-4ZTx6uDOwO2WiLi7srcOkonovvOVjeaOLw3EPBmtNSIPxLU1IEbIaWs0yCZ9MPrTgm3du33qOdpbg6qM9wHtXg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-1.0.4.tgz",
+      "integrity": "sha512-ioH4LdcCeY6b5pIJppiw86ZjYnV2SnotZkDbGrLybnbc7qTBru4EnXXgMc7bWBjnIfhslW5usHddn6nojeIphw=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -14302,18 +14302,18 @@
       }
     },
     "next-i18next": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/next-i18next/-/next-i18next-4.4.0.tgz",
-      "integrity": "sha512-cFl1K9mcQ/HRLwNdFXwJJGjtpr5URgUSbZihtFwsUD7Ib81pzSi4UfTUiCdS9Kn2gRSbtUxVWkrukGbu6rcepQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/next-i18next/-/next-i18next-4.4.1.tgz",
+      "integrity": "sha512-WsyEVqx0FPEmcC7lgCkCdolRyVewEdY2JFvZSl6344xk6DGGx5tNib0fBCGgd9zF0JFmndV+jBsep/ZJkl1gng==",
       "requires": {
         "core-js": "^2",
         "detect-node": "^2.0.4",
         "hoist-non-react-statics": "^3.2.0",
         "i18next": "^19.0.3",
         "i18next-browser-languagedetector": "^4.0.0",
-        "i18next-fs-backend": "^1.0.1",
-        "i18next-http-backend": "^1.0.4",
-        "i18next-http-middleware": "^1.0.0",
+        "i18next-fs-backend": "^1.0.2",
+        "i18next-http-backend": "^1.0.8",
+        "i18next-http-middleware": ">=1.0.2",
         "path-match": "^1.2.4",
         "prop-types": "^15.6.2",
         "react-i18next": "^11.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -18,7 +18,7 @@
     "isomorphic-fetch": "^2.2.1",
     "next": "^9.3.2",
     "next-cookies": "^2.0.3",
-    "next-i18next": "^4.4.0",
+    "next-i18next": "^4.4.1",
     "npm": "^6.14.4",
     "prop-types": "^15.7.2",
     "react": "^16.13.0",


### PR DESCRIPTION
## Summary
<!-- Por favor, referencie a issue que esse PR se refere. -->
Resolves #84 

## Relevant technical choices
Um erro ocorre ao tentar realizar o deploy para o now. Um dos motivos é que a plataforma não suporta EcmaScript Modules (mais detalhe na issue). Por isso, atualizei a lib, visto que os mantenedores liberaram recentemente (no dia 04/05) a release [4.4.1 em que passam a fazer a importação da dependência `i18next-http-backend` a partir do diretório do `cjs`](https://github.com/isaachinman/next-i18next/releases/tag/v4.4.1) justamente para evitar esse problema.

<!-- Descreva as decisões técnicas relevantes -->

## QA Steps

<!-- Passos para testar essa PR (de preferência por um não-desenvolver) -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [X] My code passes the linting.
- [X] My code has proper inline documentation.
- [X] I have manually tested this PR.
