### PR TITLE
Feature/web/custom error pages

### DIFF
--- a/packages/web/components/Header/links.js
+++ b/packages/web/components/Header/links.js
@@ -12,22 +12,22 @@ const links = [
 	{
 		id: 3,
 		label: 'Categorias',
-		href: '/categorias',
+		href: '/',
 	},
 	{
 		id: 4,
 		label: 'Desenvolvedores',
-		href: '/desenvolvedores',
+		href: '/',
 	},
 	{
 		id: 5,
 		label: 'Plataforma',
-		href: '/plataforma',
+		href: '/',
 	},
 	{
 		id: 6,
 		label: 'Contato',
-		href: '/contact',
+		href: '/',
 	},
 ];
 

--- a/packages/web/pages/404.js
+++ b/packages/web/pages/404.js
@@ -1,5 +1,0 @@
-import React from 'react';
-// pages/404.js
-const Custom404 = () => <h1>404 - Page Not Found</h1>;
-
-export default Custom404;

--- a/packages/web/pages/404.js
+++ b/packages/web/pages/404.js
@@ -1,0 +1,5 @@
+import React from 'react';
+// pages/404.js
+const Custom404 = () => <h1>404 - Page Not Found</h1>;
+
+export default Custom404;

--- a/packages/web/pages/_error.js
+++ b/packages/web/pages/_error.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+
+const Error = ({ statusCode }) => {
+	const { t } = useTranslation(['error']);
+	return <p>{statusCode ? t('error:serverError', { statusCode }) : t('error:clientError')}</p>;
+};
+
+Error.getInitialProps = async ({ res, err }) => {
+	let statusCode;
+	if (res) {
+		statusCode = res.statusCode;
+	} else if (err) {
+		statusCode = err.statusCode;
+	} else {
+		statusCode = 404;
+	}
+	return { statusCode, namespacesRequired: ['error'] };
+};
+
+Error.propTypes = {
+	statusCode: PropTypes.number.isRequired,
+};
+
+export default Error;

--- a/packages/web/pages/_error.js
+++ b/packages/web/pages/_error.js
@@ -1,14 +1,78 @@
 import React from 'react';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import { AiOutlineArrowLeft } from 'react-icons/ai';
+import { Link } from '../components/Link';
 
 const Error = ({ statusCode }) => {
 	const { t } = useTranslation(['error']);
-	if (statusCode === 404) {
-		return <h1>404 - {t('notFoundPageError')}</h1>;
-	}
-	return <h1>{statusCode ? t('serverError', { statusCode }) : t('clientError')}</h1>;
+	return (
+		<Container>
+			{statusCode ? (
+				<>
+					<h1>{statusCode}</h1>
+					<h2>
+						{statusCode === 404
+							? t('notFoundPageError')
+							: t('serverError', { statusCode })}
+					</h2>
+				</>
+			) : (
+				<h1>{t('clientError')}</h1>
+			)}
+			<Link href="/">
+				<AiOutlineArrowLeft /> {t('backButton')}
+			</Link>
+		</Container>
+	);
 };
+
+Error.propTypes = {
+	statusCode: PropTypes.number.isRequired,
+};
+
+const Container = styled.div`
+	height: 100vh;
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	background-color: ${({ theme }) => theme.colors.gray98};
+	text-align: center;
+
+	h1 {
+		color: ${({ theme }) => theme.colors.darkGray};
+		font-size: 3.6rem;
+		margin-bottom: 1.5rem;
+	}
+
+	h2 {
+		font-size: 2rem;
+	}
+
+	a {
+		margin-top: 6rem;
+		padding: 1.5rem 3rem;
+		display: flex;
+		align-items: center;
+		background-color: ${({ theme }) => theme.colors.primary};
+		color: ${({ theme }) => theme.colors.white};
+		text-transform: uppercase;
+		border-radius: ${({ theme }) => theme.metrics.baseRadius}rem;
+
+		svg {
+			margin-right: 1rem;
+		}
+
+		:hover {
+			background-color: ${({ theme }) => theme.colors.darkGray};
+			color: ${({ theme }) => theme.colors.white};
+			cursor: pointer;
+		}
+	}
+`;
 
 Error.getInitialProps = async ({ res, err }) => {
 	let statusCode;
@@ -20,10 +84,6 @@ Error.getInitialProps = async ({ res, err }) => {
 		statusCode = 404;
 	}
 	return { statusCode, namespacesRequired: ['error'] };
-};
-
-Error.propTypes = {
-	statusCode: PropTypes.number.isRequired,
 };
 
 export default Error;

--- a/packages/web/pages/_error.js
+++ b/packages/web/pages/_error.js
@@ -4,7 +4,10 @@ import { useTranslation } from 'react-i18next';
 
 const Error = ({ statusCode }) => {
 	const { t } = useTranslation(['error']);
-	return <p>{statusCode ? t('error:serverError', { statusCode }) : t('error:clientError')}</p>;
+	if (statusCode === 404) {
+		return <h1>404 - {t('notFoundPageError')}</h1>;
+	}
+	return <h1>{statusCode ? t('serverError', { statusCode }) : t('clientError')}</h1>;
 };
 
 Error.getInitialProps = async ({ res, err }) => {

--- a/packages/web/public/static/locales/en/error.json
+++ b/packages/web/public/static/locales/en/error.json
@@ -1,4 +1,5 @@
 {
+  "backButton": "Back to home page",
   "clientError": "An error occurred on client",
   "notFoundPageError": "Page not found",
   "serverError": "An error {{statusCode}} occurred on server"

--- a/packages/web/public/static/locales/en/error.json
+++ b/packages/web/public/static/locales/en/error.json
@@ -1,0 +1,4 @@
+{
+  "clientError": "An error occurred on client",
+  "serverError": "An error {{statusCode}} occurred on server"
+}

--- a/packages/web/public/static/locales/en/error.json
+++ b/packages/web/public/static/locales/en/error.json
@@ -1,4 +1,5 @@
 {
   "clientError": "An error occurred on client",
+  "notFoundPageError": "Page not found",
   "serverError": "An error {{statusCode}} occurred on server"
 }

--- a/packages/web/public/static/locales/pt/error.json
+++ b/packages/web/public/static/locales/pt/error.json
@@ -1,4 +1,5 @@
 {
+  "backButton": "Voltar à página principal",
   "clientError": "Um erro ocorreu no cliente",
   "notFoundPageError": "Página não encontrada",
   "serverError": "Um erro {{statusCode}} ocorreu no servidor"

--- a/packages/web/public/static/locales/pt/error.json
+++ b/packages/web/public/static/locales/pt/error.json
@@ -1,0 +1,4 @@
+{
+  "clientError": "Um erro ocorreu no cliente",
+  "serverError": "Um erro {{statusCode}} ocorreu no servidor"
+}

--- a/packages/web/public/static/locales/pt/error.json
+++ b/packages/web/public/static/locales/pt/error.json
@@ -1,4 +1,5 @@
 {
   "clientError": "Um erro ocorreu no cliente",
+  "notFoundPageError": "Página não encontrada",
   "serverError": "Um erro {{statusCode}} ocorreu no servidor"
 }


### PR DESCRIPTION
## Summary
Cria páginas de erro customizadas (com internacionalização).

Resolves #85 and Resolves #83

<!-- Por favor, referencie a issue que esse PR se refere. -->

## Relevant technical choices
Foi adicionada uma página de erro customizada e internacionalizada. A página exibe uma mensagem caso tenha ocorrido um erro 404 (página não encontrada) e uma outra mensagem para os demais erros, que podem ocorrer tanto no cliente quanto no servidor.

### Por que não criar uma página `404.js`?
Inicialmente, havia criado uma página `404.js` também. Entretanto, essa página é [gerada estaticamente no momento do build](https://github.com/zeit/next.js/issues/8514). Com isso, **não teríamos a opção de mostrar as mensagens personalizadas de acordo com a língua utilizada**. Inclusive, [a própria documentação proíbe que usemos `getInitialProps` na página](url), o que impediria de prover os `nameSpaces`. 
<!-- Descreva as decisões técnicas relevantes -->

## QA Steps
- Uma página com um código 404 deve ser exibido ao acessar uma página inexistente (Ex.: `http://localhost:3000/inexistente`)
- Ao ocorrer um outro tipo de erro, uma mensagem deve ser exibida contendo o código de erro.

<!-- Passos para testar essa PR (de preferência por um não-desenvolver) -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [X] My code passes the linting.
- [X] My code has proper inline documentation.
- [X] I have manually tested this PR.
