### PR TITLE
Styles/web/styled switcher

### DIFF
--- a/packages/web/components/HamburguerMenu/HamburguerMenu.js
+++ b/packages/web/components/HamburguerMenu/HamburguerMenu.js
@@ -20,7 +20,9 @@ const HamburguerMenu = ({ links }) => {
 				<NavList>
 					{links.map(({ id, label, href }) => (
 						<NavListItem key={id}>
-							<Link href={href}>{label}</Link>
+							<Link href={href} onClick={toggleMenu}>
+								{label}
+							</Link>
 						</NavListItem>
 					))}
 				</NavList>

--- a/packages/web/components/Header/LanguageSwitcher.js
+++ b/packages/web/components/Header/LanguageSwitcher.js
@@ -4,18 +4,14 @@ import styled from 'styled-components';
 
 const supportedLanguages = [
 	{
-		label: 'English',
+		label: 'EN',
 		code: 'en',
 	},
 	{
-		label: 'Português',
+		label: 'PT',
 		code: 'pt',
 	},
 ];
-
-const Select = styled.select`
-	margin-right: 1rem;
-`;
 
 const LanguageSwitcher = () => {
 	const { i18n } = useTranslation();
@@ -34,5 +30,31 @@ const LanguageSwitcher = () => {
 		</Select>
 	);
 };
+
+const Select = styled.select`
+	/* -moz-appearance: none;
+	-webkit-appearance: none; */
+	padding: 0 0.5rem;
+	height: 100%;
+	border: none;
+	background-color: ${({ theme }) => theme.colors.orange};
+	color: ${({ theme }) => theme.colors.white};
+	font-weight: 500;
+	font-size: 2rem;
+	cursor: pointer;
+
+	:hover {
+		/* background-color: ${({ theme }) => theme.colors.darkGray}; */
+		color: ${({ theme }) => theme.colors.white};
+	}
+
+	option {
+		background-color: ${({ theme }) => theme.colors.orange};
+
+		/* :hover {
+			background-color: ${({ theme }) => theme.colors.darkGray};
+		} */
+	}
+`;
 
 export default LanguageSwitcher;

--- a/packages/web/components/Header/LanguageSwitcher.js
+++ b/packages/web/components/Header/LanguageSwitcher.js
@@ -32,8 +32,6 @@ const LanguageSwitcher = () => {
 };
 
 const Select = styled.select`
-	/* -moz-appearance: none;
-	-webkit-appearance: none; */
 	padding: 0 0.5rem;
 	height: 100%;
 	border: none;
@@ -44,16 +42,11 @@ const Select = styled.select`
 	cursor: pointer;
 
 	:hover {
-		/* background-color: ${({ theme }) => theme.colors.darkGray}; */
 		color: ${({ theme }) => theme.colors.white};
 	}
 
 	option {
 		background-color: ${({ theme }) => theme.colors.orange};
-
-		/* :hover {
-			background-color: ${({ theme }) => theme.colors.darkGray};
-		} */
 	}
 `;
 

--- a/packages/web/components/Header/LanguageSwitcher.js
+++ b/packages/web/components/Header/LanguageSwitcher.js
@@ -41,10 +41,6 @@ const Select = styled.select`
 	font-size: 2rem;
 	cursor: pointer;
 
-	:hover {
-		color: ${({ theme }) => theme.colors.white};
-	}
-
 	option {
 		background-color: ${({ theme }) => theme.colors.orange};
 	}

--- a/packages/web/components/Header/styles.js
+++ b/packages/web/components/Header/styles.js
@@ -93,6 +93,7 @@ export const LoginBox = styled.div`
 		border: 0;
 		font-size: 1.2rem;
 		height: 100%;
+		min-width: 6rem;
 		padding: 0 2rem;
 		transition: color 0.3s;
 		:hover {

--- a/packages/web/components/Link/Link.js
+++ b/packages/web/components/Link/Link.js
@@ -3,10 +3,12 @@ import PropTypes from 'prop-types';
 import NextLink from 'next/link';
 import { StyledLink } from './styles';
 
-const Link = ({ children, href, as, passHref, replace, scroll, hover }) => {
+const Link = ({ children, href, as, passHref, replace, scroll, hover, onClick }) => {
 	return (
 		<NextLink href={href} as={as} passHref={passHref} replace={replace} scroll={scroll}>
-			<StyledLink hover={hover}>{children}</StyledLink>
+			<StyledLink onClick={onClick} hover={hover}>
+				{children}
+			</StyledLink>
 		</NextLink>
 	);
 };
@@ -19,6 +21,7 @@ Link.propTypes = {
 	replace: PropTypes.bool,
 	scroll: PropTypes.bool,
 	hover: PropTypes.bool,
+	onClick: PropTypes.func,
 };
 
 Link.defaultProps = {
@@ -27,6 +30,7 @@ Link.defaultProps = {
 	replace: true,
 	scroll: true,
 	hover: false,
+	onClick: () => {},
 };
 
 export default Link;


### PR DESCRIPTION
## Summary

Resolves #82. 
Estiliza o componente language switcher e corrige bug ao clicar em um dos links através do hamburguer menu (o menu não fechava).

## Relevant technical choices
- Adicionei uma prop de `onClick` para ser repassada ao filho do componente `Link`, conforme recomenda a [documentação](https://nextjs.org/docs/api-reference/next/link#using-a-component-that-supports-onclick).

## QA Steps
- Para ver o estilo do componente de seleção de linguagem, basta clicar em cima dele e selecionar uma outra língua.
- Para testar o funcionamento do menu, acesse a plataforma em uma tela menor (ou diminua a tela através das ferramentas do seu navegador) e clique na págian de busca para que o usuário seja redirecionado e o menu fechado.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [X] My code passes the linting.
- [X] My code has proper inline documentation.
- [X] I have manually tested this PR.
