### PR TITLE
SSR algolia results

### DIFF
--- a/packages/web/components/Algolia/provider.js
+++ b/packages/web/components/Algolia/provider.js
@@ -38,6 +38,7 @@ const AlgoliaSearchProvider = ({
 	onSearchStateChange,
 	createURL,
 	resultsState,
+	onSearchParameters,
 }) => (
 	<InstantSearch
 		indexName={defaultIndexName}
@@ -46,6 +47,7 @@ const AlgoliaSearchProvider = ({
 		searchState={searchState}
 		createURL={createURL}
 		resultsState={resultsState}
+		onSearchParameters={onSearchParameters}
 	>
 		{children}
 	</InstantSearch>
@@ -59,6 +61,7 @@ AlgoliaSearchProvider.propTypes = {
 	onSearchStateChange: PropTypes.func,
 	createURL: PropTypes.func,
 	resultsState: PropTypes.shape({}),
+	onSearchParameters: PropTypes.func,
 };
 
 AlgoliaSearchProvider.defaultProps = {
@@ -67,6 +70,7 @@ AlgoliaSearchProvider.defaultProps = {
 	onSearchStateChange: null,
 	createURL: null,
 	resultsState: null,
+	onSearchParameters: null,
 };
 
 export default AlgoliaSearchProvider;

--- a/packages/web/components/Algolia/provider.js
+++ b/packages/web/components/Algolia/provider.js
@@ -3,10 +3,17 @@ import PropTypes from 'prop-types';
 import algoliasearch from 'algoliasearch/lite';
 import { InstantSearch } from 'react-instantsearch-dom';
 
-export const algoliaClient = algoliasearch(
+const algoliaClient = algoliasearch(
 	process.env.ALGOLIA_APPLICATION_ID,
 	process.env.ALGOLIA_SEARCH_KEY,
 );
+
+const defaultIndexName = 'searchable_data';
+
+export const algoliaDefaultConfig = {
+	searchClient: algoliaClient,
+	indexName: defaultIndexName,
+};
 
 const searchClient = {
 	search(requests) {
@@ -30,13 +37,15 @@ const AlgoliaSearchProvider = ({
 	searchState,
 	onSearchStateChange,
 	createURL,
+	resultsState,
 }) => (
 	<InstantSearch
-		indexName="searchable_data"
+		indexName={defaultIndexName}
 		searchClient={useProxy ? searchClient : algoliaClient}
 		onSearchStateChange={onSearchStateChange}
 		searchState={searchState}
 		createURL={createURL}
+		resultsState={resultsState}
 	>
 		{children}
 	</InstantSearch>
@@ -49,13 +58,15 @@ AlgoliaSearchProvider.propTypes = {
 	searchState: PropTypes.shape({}),
 	onSearchStateChange: PropTypes.func,
 	createURL: PropTypes.func,
+	resultsState: PropTypes.shape({}),
 };
 
 AlgoliaSearchProvider.defaultProps = {
-	useProxy: true,
+	useProxy: false,
 	searchState: null,
 	onSearchStateChange: null,
 	createURL: null,
+	resultsState: null,
 };
 
 export default AlgoliaSearchProvider;

--- a/packages/web/components/Hero/HeroSearch/HeroSearch.js
+++ b/packages/web/components/Hero/HeroSearch/HeroSearch.js
@@ -16,7 +16,7 @@ const HeroSearch = () => {
 		});
 	};
 	return (
-		<AlgoliaSearchProvider>
+		<AlgoliaSearchProvider useProxy>
 			<SearchBox
 				placeholder={t('search:searchPlaceholder')}
 				onChange={(e) => setTermQuery(e.currentTarget.value)}

--- a/packages/web/components/MainSearch/MainSearch.js
+++ b/packages/web/components/MainSearch/MainSearch.js
@@ -28,7 +28,13 @@ import {
 	ToggleRefinement,
 } from '../Algolia';
 
-const MainSearch = ({ searchState, resultsState, onSearchStateChange, createURL }) => {
+const MainSearch = ({
+	searchState,
+	resultsState,
+	onSearchStateChange,
+	createURL,
+	onSearchParameters,
+}) => {
 	const { t } = useTranslation(['search', 'common']);
 	return (
 		<AlgoliaSearchProvider
@@ -36,6 +42,7 @@ const MainSearch = ({ searchState, resultsState, onSearchStateChange, createURL 
 			resultsState={resultsState}
 			onSearchStateChange={onSearchStateChange}
 			createURL={createURL}
+			onSearchParameters={onSearchParameters}
 		>
 			<ThemeProvider>
 				<SearchBoxContainer>
@@ -122,12 +129,14 @@ MainSearch.propTypes = {
 	onSearchStateChange: PropTypes.func,
 	createURL: PropTypes.func,
 	resultsState: PropTypes.shape({}),
+	onSearchParameters: PropTypes.func,
 };
 
 MainSearch.defaultProps = {
 	onSearchStateChange: null,
 	createURL: null,
 	resultsState: null,
+	onSearchParameters: null,
 };
 
 export default MainSearch;

--- a/packages/web/components/MainSearch/MainSearch.js
+++ b/packages/web/components/MainSearch/MainSearch.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Hits } from 'react-instantsearch-dom';
 import { useTranslation } from 'react-i18next';
+import { ThemeProvider } from '../../styles';
 
 import {
 	SearchBoxContainer,
@@ -13,6 +15,7 @@ import {
 } from './styles';
 
 import {
+	AlgoliaSearchProvider,
 	DebouncedSearchBox,
 	Stats,
 	SortBy,
@@ -25,86 +28,106 @@ import {
 	ToggleRefinement,
 } from '../Algolia';
 
-const MainSearch = () => {
+const MainSearch = ({ searchState, resultsState, onSearchStateChange, createURL }) => {
 	const { t } = useTranslation(['search', 'common']);
 	return (
-		<>
-			<SearchBoxContainer>
-				<DebouncedSearchBox placeholder={t('search:searchPlaceholder')} />
-			</SearchBoxContainer>
+		<AlgoliaSearchProvider
+			searchState={searchState}
+			resultsState={resultsState}
+			onSearchStateChange={onSearchStateChange}
+			createURL={createURL}
+		>
+			<ThemeProvider>
+				<SearchBoxContainer>
+					<DebouncedSearchBox placeholder={t('search:searchPlaceholder')} />
+				</SearchBoxContainer>
 
-			<Container>
-				<FilterContainer>
-					<FilterContainerHeader>
-						<h2>{t('common:filters')}</h2>
-						<ClearRefinements placeholder={t('common:clear')} />
-					</FilterContainerHeader>
-					<Panel header={t('common:region')}>
-						<RefinementList
-							attribute="region"
-							placeholder={t('search:searchRegionPlaceholder')}
-						/>
-					</Panel>
-					<Panel header={t('common:technologies')}>
-						<ToggleRefinement
-							attribute="private"
-							label={t('search:filterOnlyPublic')}
-							value={0}
-						/>
-					</Panel>
-					<Panel header={t('common:category')}>
-						<RefinementList
-							attribute="category"
-							placeholder={t('search:searchCategoryPlaceholder')}
-						/>
-					</Panel>
-				</FilterContainer>
-				<ResultsContainer>
-					<ResultsContainerHeader>
-						<Stats />
-						<SortBy
-							defaultRefinement="searchable_data"
-							items={[
-								{
-									label: t('search:sortByRelevance'),
-									value: 'searchable_data',
-								},
-								{
-									label: t('search:sortByPriceAsc'),
-									value: 'searchable_data_price_asc',
-								},
-								{
-									label: t('search:sortByPriceDesc'),
-									value: 'searchable_data_price_desc',
-								},
-							]}
-						/>
-						<HitsPerPage
-							items={[
-								{
-									label: t('search:perPage', { results: 12 }),
-									value: 12,
-								},
-								{
-									label: t('search:perPage', { results: 24 }),
-									value: 24,
-								},
-								{
-									label: t('search:perPage', { results: 36 }),
-									value: 36,
-								},
-							]}
-							defaultRefinement={12}
-						/>
-					</ResultsContainerHeader>
-					<Hits hitComponent={HitCard} />
-					<ResultsFooter>
-						<Pagination />
-					</ResultsFooter>
-				</ResultsContainer>
-			</Container>
-		</>
+				<Container>
+					<FilterContainer>
+						<FilterContainerHeader>
+							<h2>{t('common:filters')}</h2>
+							<ClearRefinements placeholder={t('common:clear')} />
+						</FilterContainerHeader>
+						<Panel header={t('common:region')}>
+							<RefinementList
+								attribute="region"
+								placeholder={t('search:searchRegionPlaceholder')}
+							/>
+						</Panel>
+						<Panel header={t('common:technologies')}>
+							<ToggleRefinement
+								attribute="private"
+								label={t('search:filterOnlyPublic')}
+								value={0}
+							/>
+						</Panel>
+						<Panel header={t('common:category')}>
+							<RefinementList
+								attribute="category"
+								placeholder={t('search:searchCategoryPlaceholder')}
+							/>
+						</Panel>
+					</FilterContainer>
+					<ResultsContainer>
+						<ResultsContainerHeader>
+							<Stats />
+							<SortBy
+								defaultRefinement="searchable_data"
+								items={[
+									{
+										label: t('search:sortByRelevance'),
+										value: 'searchable_data',
+									},
+									{
+										label: t('search:sortByPriceAsc'),
+										value: 'searchable_data_price_asc',
+									},
+									{
+										label: t('search:sortByPriceDesc'),
+										value: 'searchable_data_price_desc',
+									},
+								]}
+							/>
+							<HitsPerPage
+								items={[
+									{
+										label: t('search:perPage', { results: 12 }),
+										value: 12,
+									},
+									{
+										label: t('search:perPage', { results: 24 }),
+										value: 24,
+									},
+									{
+										label: t('search:perPage', { results: 36 }),
+										value: 36,
+									},
+								]}
+								defaultRefinement={12}
+							/>
+						</ResultsContainerHeader>
+						<Hits hitComponent={HitCard} />
+						<ResultsFooter>
+							<Pagination />
+						</ResultsFooter>
+					</ResultsContainer>
+				</Container>
+			</ThemeProvider>
+		</AlgoliaSearchProvider>
 	);
+};
+
+MainSearch.propTypes = {
+	searchState: PropTypes.shape({}).isRequired,
+	onSearchStateChange: PropTypes.func,
+	createURL: PropTypes.func,
+	resultsState: PropTypes.shape({}),
+};
+
+MainSearch.defaultProps = {
+	onSearchStateChange: null,
+	createURL: null,
+	resultsState: null,
 };
 
 export default MainSearch;

--- a/packages/web/components/MainSearch/MainSearch.js
+++ b/packages/web/components/MainSearch/MainSearch.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import { Hits } from 'react-instantsearch-dom';
+import { useTranslation } from 'react-i18next';
+
+import {
+	SearchBoxContainer,
+	Container,
+	FilterContainer,
+	FilterContainerHeader,
+	ResultsContainer,
+	ResultsContainerHeader,
+	ResultsFooter,
+} from './styles';
+
+import {
+	DebouncedSearchBox,
+	Stats,
+	SortBy,
+	HitsPerPage,
+	HitCard,
+	Pagination,
+	ClearRefinements,
+	Panel,
+	RefinementList,
+	ToggleRefinement,
+} from '../Algolia';
+
+const MainSearch = () => {
+	const { t } = useTranslation(['search', 'common']);
+	return (
+		<>
+			<SearchBoxContainer>
+				<DebouncedSearchBox placeholder={t('search:searchPlaceholder')} />
+			</SearchBoxContainer>
+
+			<Container>
+				<FilterContainer>
+					<FilterContainerHeader>
+						<h2>{t('common:filters')}</h2>
+						<ClearRefinements placeholder={t('common:clear')} />
+					</FilterContainerHeader>
+					<Panel header={t('common:region')}>
+						<RefinementList
+							attribute="region"
+							placeholder={t('search:searchRegionPlaceholder')}
+						/>
+					</Panel>
+					<Panel header={t('common:technologies')}>
+						<ToggleRefinement
+							attribute="private"
+							label={t('search:filterOnlyPublic')}
+							value={0}
+						/>
+					</Panel>
+					<Panel header={t('common:category')}>
+						<RefinementList
+							attribute="category"
+							placeholder={t('search:searchCategoryPlaceholder')}
+						/>
+					</Panel>
+				</FilterContainer>
+				<ResultsContainer>
+					<ResultsContainerHeader>
+						<Stats />
+						<SortBy
+							defaultRefinement="searchable_data"
+							items={[
+								{
+									label: t('search:sortByRelevance'),
+									value: 'searchable_data',
+								},
+								{
+									label: t('search:sortByPriceAsc'),
+									value: 'searchable_data_price_asc',
+								},
+								{
+									label: t('search:sortByPriceDesc'),
+									value: 'searchable_data_price_desc',
+								},
+							]}
+						/>
+						<HitsPerPage
+							items={[
+								{
+									label: t('search:perPage', { results: 12 }),
+									value: 12,
+								},
+								{
+									label: t('search:perPage', { results: 24 }),
+									value: 24,
+								},
+								{
+									label: t('search:perPage', { results: 36 }),
+									value: 36,
+								},
+							]}
+							defaultRefinement={12}
+						/>
+					</ResultsContainerHeader>
+					<Hits hitComponent={HitCard} />
+					<ResultsFooter>
+						<Pagination />
+					</ResultsFooter>
+				</ResultsContainer>
+			</Container>
+		</>
+	);
+};
+
+export default MainSearch;

--- a/packages/web/components/MainSearch/index.js
+++ b/packages/web/components/MainSearch/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as MainSearch } from './MainSearch';

--- a/packages/web/components/MainSearch/styles.js
+++ b/packages/web/components/MainSearch/styles.js
@@ -1,0 +1,61 @@
+import styled from 'styled-components';
+
+export const SearchBoxContainer = styled.div`
+	border: 2rem solid ${({ theme }) => theme.colors.orange};
+`;
+
+export const Container = styled.main`
+	display: flex;
+	margin: 0 auto;
+	background-color: ${({ theme }) => theme.colors.whiteSmoke};
+	padding: 3rem 4rem 6rem;
+`;
+
+export const FilterContainer = styled.section`
+	flex: 1;
+	margin-right: 3rem;
+	min-width: 30rem;
+`;
+
+export const FilterContainerHeader = styled.div`
+	display: flex;
+	align-items: center;
+	min-height: 8rem;
+	border-bottom: 0.1rem solid ${({ theme }) => theme.colors.border};
+
+	h2 {
+		flex: 1;
+		font-size: 2.4rem;
+	}
+`;
+
+export const ResultsContainer = styled.section`
+	width: 100%;
+
+	.ais-Hits {
+		padding-top: 4rem;
+
+		.ais-Hits-list {
+			display: grid;
+			grid-template-columns: repeat(auto-fill, minmax(32rem, 1fr));
+			grid-gap: 5rem 3rem;
+		}
+	}
+`;
+
+export const ResultsContainerHeader = styled.div`
+	min-height: 8rem;
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
+	border-bottom: 0.1rem solid ${({ theme }) => theme.colors.border};
+
+	> div:not(:first-child) {
+		margin-left: 3rem;
+	}
+`;
+
+export const ResultsFooter = styled.footer`
+	width: 100%;
+	margin-top: 5rem;
+`;

--- a/packages/web/hooks/index.js
+++ b/packages/web/hooks/index.js
@@ -1,4 +1,3 @@
 export { default as useTheme } from './useTheme';
 export { default as useModal } from './useModal';
 export { default as useAuth } from './useAuth';
-export { default as useURLSync } from './useURLSync';

--- a/packages/web/pages/search.js
+++ b/packages/web/pages/search.js
@@ -1,81 +1,11 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import qs from 'query-string';
-import { findResultsState } from 'react-instantsearch-dom/server';
 import { withRouter } from 'next/router';
 import Head from '../components/head';
 import { MainSearch } from '../components/MainSearch';
-import { algoliaDefaultConfig } from '../components/Algolia/provider';
+import { searchStateToURL, urlToSearchState, findResultsState } from '../utils/algoliaHelper';
 
 const DEBOUNCE_TIME = 200;
-
-const encodedCategories = {
-	agua: 'Água',
-	saneamento: 'Saneamento',
-	'energia-eletrica': 'Energia Elétrica',
-	'energia-solar': 'Energia Solar',
-};
-
-const decodedCategories = Object.keys(encodedCategories).reduce((acc, key) => {
-	const newKey = encodedCategories[key];
-	const newValue = key;
-
-	return {
-		...acc,
-		[newKey]: newValue,
-	};
-}, {});
-
-const createURL = (state) => {
-	const isDefaultRoute =
-		!state.query &&
-		state.page === 1 &&
-		state.refinementList &&
-		state.refinementList.category.length === 0;
-
-	if (isDefaultRoute) {
-		return '/search';
-	}
-
-	const queryParameters = {};
-
-	if (state.query) {
-		queryParameters.query = encodeURIComponent(state.query);
-	}
-	if (state.page !== 1) {
-		queryParameters.page = state.page;
-	}
-	if (state.refinementList.category) {
-		queryParameters.categories = state.refinementList.category
-			.map((category) => decodedCategories[category] || category)
-			.map(encodeURIComponent);
-	}
-
-	const queryString = qs.stringifyUrl(
-		{ url: '', query: queryParameters },
-		{ arrayFormat: 'comma' },
-	);
-
-	return `/search${queryString}`;
-};
-
-const searchStateToURL = (searchState) => (searchState ? createURL(searchState) : '');
-
-const urlToSearchState = (path) => {
-	const url = path.includes('?') ? qs.parse(path.substring(path.indexOf('?') + 1)) : {};
-	const { query = '', page = 1 } = url;
-	const allCategories = url?.categories ? url.categories.split(',') : [];
-
-	return {
-		query: decodeURIComponent(query),
-		page,
-		refinementList: {
-			category: allCategories
-				.map((category) => encodedCategories[category] || category)
-				.map(decodeURIComponent),
-		},
-	};
-};
 
 const SearchPage = ({ initialSearchState, resultsState, router }) => {
 	const [searchState, setSearchState] = useState(initialSearchState);
@@ -118,10 +48,7 @@ SearchPage.propTypes = {
 
 SearchPage.getInitialProps = async ({ asPath }) => {
 	const initialSearchState = urlToSearchState(asPath);
-	const resultsState = await findResultsState(MainSearch, {
-		...algoliaDefaultConfig,
-		searchState: initialSearchState,
-	});
+	const resultsState = await findResultsState(MainSearch, initialSearchState);
 	return {
 		namespacesRequired: ['common', 'search'],
 		initialSearchState,

--- a/packages/web/pages/search.js
+++ b/packages/web/pages/search.js
@@ -1,15 +1,16 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import Head from '../components/head';
 import { MainSearch } from '../components/MainSearch';
 import { searchStateToURL, urlToSearchState, findResultsState } from '../utils/algoliaHelper';
 
 const DEBOUNCE_TIME = 200;
 
-const SearchPage = ({ initialSearchState, resultsState, router }) => {
+const SearchPage = ({ initialSearchState, resultsState }) => {
 	const [searchState, setSearchState] = useState(initialSearchState);
 	const [debouncedSetState, setDebouncedSetState] = useState(null);
+	const router = useRouter();
 
 	const onSearchStateChange = (newSearchState) => {
 		clearTimeout(debouncedSetState);
@@ -41,9 +42,6 @@ const SearchPage = ({ initialSearchState, resultsState, router }) => {
 SearchPage.propTypes = {
 	initialSearchState: PropTypes.shape({}).isRequired,
 	resultsState: PropTypes.shape({}).isRequired,
-	router: PropTypes.shape({
-		push: PropTypes.func,
-	}).isRequired,
 };
 
 SearchPage.getInitialProps = async ({ asPath }) => {
@@ -56,4 +54,4 @@ SearchPage.getInitialProps = async ({ asPath }) => {
 	};
 };
 
-export default withRouter(SearchPage);
+export default SearchPage;

--- a/packages/web/pages/search.js
+++ b/packages/web/pages/search.js
@@ -1,186 +1,134 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
-import { Hits } from 'react-instantsearch-dom';
-import { useTranslation } from 'react-i18next';
+import qs from 'query-string';
+import { findResultsState } from 'react-instantsearch-dom/server';
+import { withRouter } from 'next/router';
 import Head from '../components/head';
-import { useURLSync } from '../hooks';
+import { MainSearch } from '../components/MainSearch';
+import AlgoliaSearchProvider, { algoliaDefaultConfig } from '../components/Algolia/provider';
 
-import {
-	AlgoliaSearchProvider,
-	DebouncedSearchBox,
-	Stats,
-	SortBy,
-	HitsPerPage,
-	HitCard,
-	Pagination,
-	ClearRefinements,
-	Panel,
-	RefinementList,
-	ToggleRefinement,
-} from '../components/Algolia';
+const DEBOUNCE_TIME = 200;
 
-const Search = () => {
-	const { searchState, createURL, onSearchStateChange } = useURLSync();
-	const { t } = useTranslation(['search', 'common']);
-	return (
-		<AlgoliaSearchProvider
-			useProxy={false}
-			searchState={searchState}
-			createURL={createURL}
-			onSearchStateChange={onSearchStateChange}
-		>
-			<Head title="Search" />
-			<SearchBoxContainer>
-				<DebouncedSearchBox placeholder={t('search:searchPlaceholder')} />
-			</SearchBoxContainer>
-
-			<Container>
-				<FilterContainer>
-					<FilterContainerHeader>
-						<h2>{t('common:filters')}</h2>
-						<ClearRefinements placeholder={t('common:clear')} />
-					</FilterContainerHeader>
-					<Panel header={t('common:region')}>
-						<RefinementList
-							attribute="region"
-							placeholder={t('search:searchRegionPlaceholder')}
-						/>
-					</Panel>
-					<Panel header={t('common:technologies')}>
-						<ToggleRefinement
-							attribute="private"
-							label={t('search:filterOnlyPublic')}
-							value={0}
-						/>
-					</Panel>
-					<Panel header={t('common:category')}>
-						<RefinementList
-							attribute="category"
-							placeholder={t('search:searchCategoryPlaceholder')}
-						/>
-					</Panel>
-				</FilterContainer>
-				<ResultsContainer>
-					<ResultsContainerHeader>
-						<Stats />
-						<SortBy
-							defaultRefinement="searchable_data"
-							items={[
-								{
-									label: t('search:sortByRelevance'),
-									value: 'searchable_data',
-								},
-								{
-									label: t('search:sortByPriceAsc'),
-									value: 'searchable_data_price_asc',
-								},
-								{
-									label: t('search:sortByPriceDesc'),
-									value: 'searchable_data_price_desc',
-								},
-							]}
-						/>
-						<HitsPerPage
-							items={[
-								{
-									label: t('search:perPage', { results: 12 }),
-									value: 12,
-								},
-								{
-									label: t('search:perPage', { results: 24 }),
-									value: 24,
-								},
-								{
-									label: t('search:perPage', { results: 36 }),
-									value: 36,
-								},
-							]}
-							defaultRefinement={12}
-						/>
-					</ResultsContainerHeader>
-					<Hits hitComponent={HitCard} />
-					<ResultsFooter>
-						<Pagination />
-					</ResultsFooter>
-				</ResultsContainer>
-			</Container>
-		</AlgoliaSearchProvider>
-	);
+const encodedCategories = {
+	agua: 'Água',
+	saneamento: 'Saneamento',
+	'energia-eletrica': 'Energia Elétrica',
+	'energia-solar': 'Energia Solar',
 };
 
-const SearchBoxContainer = styled.div`
-	border: 2rem solid ${({ theme }) => theme.colors.orange};
-`;
+const decodedCategories = Object.keys(encodedCategories).reduce((acc, key) => {
+	const newKey = encodedCategories[key];
+	const newValue = key;
 
-const Container = styled.main`
-	display: flex;
-	margin: 0 auto;
-	background-color: ${({ theme }) => theme.colors.whiteSmoke};
-	padding: 3rem 4rem 6rem;
-`;
-
-const FilterContainer = styled.section`
-	flex: 1;
-	margin-right: 3rem;
-	min-width: 30rem;
-`;
-
-const FilterContainerHeader = styled.div`
-	display: flex;
-	align-items: center;
-	min-height: 8rem;
-	border-bottom: 0.1rem solid ${({ theme }) => theme.colors.border};
-
-	h2 {
-		flex: 1;
-		font-size: 2.4rem;
-	}
-`;
-
-const ResultsContainer = styled.section`
-	width: 100%;
-
-	.ais-Hits {
-		padding-top: 4rem;
-
-		.ais-Hits-list {
-			display: grid;
-			grid-template-columns: repeat(auto-fill, minmax(32rem, 1fr));
-			grid-gap: 5rem 3rem;
-		}
-	}
-`;
-
-const ResultsContainerHeader = styled.div`
-	min-height: 8rem;
-	display: flex;
-	justify-content: flex-end;
-	align-items: center;
-	border-bottom: 0.1rem solid ${({ theme }) => theme.colors.border};
-
-	> div:not(:first-child) {
-		margin-left: 3rem;
-	}
-`;
-
-const ResultsFooter = styled.footer`
-	width: 100%;
-	margin-top: 5rem;
-`;
-
-Search.propTypes = {
-	searchState: PropTypes.shape({}),
-};
-
-Search.defaultProps = {
-	searchState: undefined,
-};
-
-Search.getInitialProps = async () => {
 	return {
-		namespacesRequired: ['common', 'search'],
+		...acc,
+		[newKey]: newValue,
+	};
+}, {});
+
+const createURL = (state) => {
+	const isDefaultRoute =
+		!state.query &&
+		state.page === 1 &&
+		state.refinementList &&
+		state.refinementList.category.length === 0;
+
+	if (isDefaultRoute) {
+		return '/search';
+	}
+
+	const queryParameters = {};
+
+	if (state.query) {
+		queryParameters.query = encodeURIComponent(state.query);
+	}
+	if (state.page !== 1) {
+		queryParameters.page = state.page;
+	}
+	if (state.refinementList.category) {
+		queryParameters.categories = state.refinementList.category
+			.map((category) => decodedCategories[category] || category)
+			.map(encodeURIComponent);
+	}
+
+	const queryString = qs.stringifyUrl(
+		{ url: '', query: queryParameters },
+		{ arrayFormat: 'comma' },
+	);
+
+	return `/search${queryString}`;
+};
+
+const searchStateToURL = (searchState) => (searchState ? createURL(searchState) : '');
+
+const urlToSearchState = (path) => {
+	const url = path.includes('?') ? qs.parse(path.substring(path.indexOf('?') + 1)) : {};
+	const { query = '', page = 1 } = url;
+	const allCategories = url?.categories ? url.categories.split(',') : [];
+
+	return {
+		query: decodeURIComponent(query),
+		page,
+		refinementList: {
+			category: allCategories
+				.map((category) => encodedCategories[category] || category)
+				.map(decodeURIComponent),
+		},
 	};
 };
 
-export default Search;
+const SearchPage = ({ initialSearchState, resultsState, router }) => {
+	const [searchState, setSearchState] = useState(initialSearchState);
+	const [debouncedSetState, setDebouncedSetState] = useState(null);
+
+	const onSearchStateChange = (newSearchState) => {
+		clearTimeout(debouncedSetState);
+
+		setDebouncedSetState(
+			setTimeout(() => {
+				const href = searchStateToURL(newSearchState);
+
+				router.push(href, href, { shallow: true });
+			}, DEBOUNCE_TIME),
+		);
+
+		setSearchState(newSearchState);
+	};
+
+	return (
+		<>
+			<Head title="Search" />
+			<AlgoliaSearchProvider
+				searchState={searchState}
+				resultsState={resultsState}
+				onSearchStateChange={onSearchStateChange}
+				createURL={searchStateToURL}
+			>
+				<MainSearch />
+			</AlgoliaSearchProvider>
+		</>
+	);
+};
+
+SearchPage.propTypes = {
+	initialSearchState: PropTypes.shape({}).isRequired,
+	resultsState: PropTypes.shape({}).isRequired,
+	router: PropTypes.shape({
+		push: PropTypes.func,
+	}).isRequired,
+};
+
+SearchPage.getInitialProps = async ({ asPath }) => {
+	const initialSearchState = urlToSearchState(asPath);
+	const resultsState = await findResultsState(AlgoliaSearchProvider, {
+		...algoliaDefaultConfig,
+		searchState: initialSearchState,
+	});
+	return {
+		namespacesRequired: ['common', 'search'],
+		initialSearchState,
+		resultsState,
+	};
+};
+
+export default withRouter(SearchPage);

--- a/packages/web/pages/search.js
+++ b/packages/web/pages/search.js
@@ -5,7 +5,7 @@ import { findResultsState } from 'react-instantsearch-dom/server';
 import { withRouter } from 'next/router';
 import Head from '../components/head';
 import { MainSearch } from '../components/MainSearch';
-import AlgoliaSearchProvider, { algoliaDefaultConfig } from '../components/Algolia/provider';
+import { algoliaDefaultConfig } from '../components/Algolia/provider';
 
 const DEBOUNCE_TIME = 200;
 
@@ -98,14 +98,12 @@ const SearchPage = ({ initialSearchState, resultsState, router }) => {
 	return (
 		<>
 			<Head title="Search" />
-			<AlgoliaSearchProvider
+			<MainSearch
 				searchState={searchState}
 				resultsState={resultsState}
 				onSearchStateChange={onSearchStateChange}
 				createURL={searchStateToURL}
-			>
-				<MainSearch />
-			</AlgoliaSearchProvider>
+			/>
 		</>
 	);
 };
@@ -120,7 +118,7 @@ SearchPage.propTypes = {
 
 SearchPage.getInitialProps = async ({ asPath }) => {
 	const initialSearchState = urlToSearchState(asPath);
-	const resultsState = await findResultsState(AlgoliaSearchProvider, {
+	const resultsState = await findResultsState(MainSearch, {
 		...algoliaDefaultConfig,
 		searchState: initialSearchState,
 	});


### PR DESCRIPTION
## Summary
Resolves #102.

## Relevant technical choices
Foi necessário fazer uma mudança considerável na estrutura anterior (utiliza um hook `useURLSync.js`) e, inclusive, ficou um pouco "engessado", porém, isso ocorreu por alguns motivos:
- É necessário usar o [getInitialProps](https://nextjs.org/docs/api-reference/data-fetching/getInitialProps) para já receber a página com os dados populados do servidor. Porém, ele **não pode ser usado em componentes filhos**. Logo, temos de usá-lo no export default da página em si.
- O [resultsState](https://www.algolia.com/doc/guides/building-search-ui/going-further/server-side-rendering/react/#serverjs) injeta os resultados que são usados na primeira renderização. Ele espera um argumento que é o componente pai do `InstantSearch` que contém os `widgets` para montar na página. Por isso, o "núcleo" da busca teve de ser separado em outro componente.
- Era necessário usar o `resultsState`dentro do `getInitialProps` para renderizar o resultado inicial do lado do servidor. Daí a mudança na estrutra.

## QA Steps
- Tente acessar uma url diretamente e veja que os resultados, agora, não são renderizados do lado do cliente (após a página montar), mas, são redenrizados já no servidor e a página já exibida completamente. Ex.:
```
https://plataforma-sabia.herokuapp.com/search?query=centro
https://plataforma-sabia.herokuapp.com/search?query=nor&categories=agua
``` 
- Faça uma busca na página principal e pressione o enter ou clique no botão de submit, e veja que os resultados continuam sendo filtrados na página de busca principal.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [X] My code passes the linting.
- [X] My code has proper inline documentation.
- [X] I have manually tested this PR.
