### PR TITLE
Feature/improve technology routes

### DIFF
--- a/packages/api/app/Controllers/Http/TechnologyController.js
+++ b/packages/api/app/Controllers/Http/TechnologyController.js
@@ -181,6 +181,18 @@ class TechnologyController {
 				.where('id', technology.id)
 				.fetch();
 		}
+		const { terms } = request.only(['terms']);
+		if (terms) {
+			const termPromises = [];
+			for (const term of terms) {
+				const termObj = Term.getTerm(term);
+				termPromises.push(termObj);
+			}
+			const allTerms = await Promise.all(termPromises);
+			const allTermsIds = allTerms.map((term) => term.id);
+			await technology.terms().attach(allTermsIds);
+			await technology.load('terms');
+		}
 		return technology;
 	}
 

--- a/packages/api/app/Controllers/Http/TechnologyController.js
+++ b/packages/api/app/Controllers/Http/TechnologyController.js
@@ -205,7 +205,8 @@ class TechnologyController {
 
 	/**
 	 * Create/save a new technology.
-	 * POST technologies
+	 * If terms is provided, it adds the related terms
+	 * If users is provided, it adds the related users
 	 */
 	async store({ request }) {
 		const data = getFields(request);
@@ -261,6 +262,8 @@ class TechnologyController {
 			await this.syncronizeTerms(terms, technology, true);
 			await technology.load('terms.taxonomy');
 		}
+
+		this.indexToAlgolia(technology);
 
 		return technology;
 	}

--- a/packages/api/app/Controllers/Http/TechnologyController.js
+++ b/packages/api/app/Controllers/Http/TechnologyController.js
@@ -176,10 +176,7 @@ class TechnologyController {
 		const { users } = request.only(['users']);
 		if (users) {
 			await this.syncronizeUsers(users, technology);
-			return Technology.query()
-				.with('users')
-				.where('id', technology.id)
-				.fetch();
+			await technology.load('users');
 		}
 		const { terms } = request.only(['terms']);
 		if (terms) {
@@ -202,10 +199,8 @@ class TechnologyController {
 		const { idTechnology } = params;
 		const technology = await Technology.findOrFail(idTechnology);
 		await this.syncronizeUsers(users, technology);
-		return Technology.query()
-			.with('users')
-			.where('id', technology.id)
-			.fetch();
+		await technology.load('users');
+		return technology;
 	}
 
 	/**
@@ -228,10 +223,7 @@ class TechnologyController {
 		const { users } = request.only(['users']);
 		if (users) {
 			await this.syncronizeUsers(users, technology, true);
-			return Technology.query()
-				.with('users')
-				.where('id', technology.id)
-				.fetch();
+			await technology.load('users');
 		}
 
 		return technology;

--- a/packages/api/app/Models/Technology.js
+++ b/packages/api/app/Models/Technology.js
@@ -19,6 +19,7 @@ class Technology extends Model {
 			try {
 				indexObject.saveObject(technology.toJSON());
 			} catch (e) {
+				// eslint-disable-next-line no-console
 				console.warn('Check your algolia settings');
 			}
 		});
@@ -27,6 +28,7 @@ class Technology extends Model {
 			try {
 				indexObject.deleteObject(technology.toJSON().objectID);
 			} catch (e) {
+				// eslint-disable-next-line no-console
 				console.warn('Check your algolia settings');
 			}
 		});

--- a/packages/api/app/Models/Technology.js
+++ b/packages/api/app/Models/Technology.js
@@ -15,15 +15,6 @@ class Technology extends Model {
 			technology.slug = slugify(technology.title, { lower: true });
 		});
 
-		this.addHook('afterSave', async (technology) => {
-			try {
-				indexObject.saveObject(technology.toJSON());
-			} catch (e) {
-				// eslint-disable-next-line no-console
-				console.warn('Check your algolia settings');
-			}
-		});
-
 		this.addHook('afterDelete', async (technology) => {
 			try {
 				indexObject.deleteObject(technology.toJSON().objectID);

--- a/packages/api/app/Models/User.js
+++ b/packages/api/app/Models/User.js
@@ -28,6 +28,10 @@ class User extends Model {
 		return ['full_name'];
 	}
 
+	static get hidden() {
+		return ['password'];
+	}
+
 	getFullName({ first_name, last_name }) {
 		return `${first_name} ${last_name}`;
 	}

--- a/packages/api/app/Utils/index.js
+++ b/packages/api/app/Utils/index.js
@@ -1,9 +1,11 @@
 const errors = require('./errors');
 const messages = require('./messages');
 const localization = require('./localization');
+const transaction = require('./transaction');
 
 module.exports = {
 	...errors,
 	...messages,
 	...localization,
+	...transaction,
 };

--- a/packages/api/app/Utils/transaction.js
+++ b/packages/api/app/Utils/transaction.js
@@ -1,0 +1,18 @@
+const Database = use('Database');
+
+module.exports.getTransaction = () => {
+	// eslint-disable-next-line no-underscore-dangle
+	const globalTrx = Database.connection('mysql')._globalTrx;
+	let trx;
+	return {
+		init: async () => {
+			trx = globalTrx || (await Database.beginTransaction());
+			return trx;
+		},
+		commit: async () => {
+			if (!globalTrx) {
+				await trx.commit();
+			}
+		},
+	};
+};

--- a/packages/api/test/functional/technology.spec.js
+++ b/packages/api/test/functional/technology.spec.js
@@ -495,6 +495,7 @@ test('POST /technologies creates/saves a new technology even if an invalid field
 
 test('POST /technologies does not create/save a new technology if an inexistent term is provided', async ({
 	client,
+	assert,
 }) => {
 	const technologyWithInvalidTerms = { ...technology, terms: [99999] };
 
@@ -505,6 +506,8 @@ test('POST /technologies does not create/save a new technology if an inexistent 
 		.loginVia(loggeduser, 'jwt')
 		.send(technologyWithInvalidTerms)
 		.end();
+
+	assert.equal(response.body.id, undefined);
 
 	response.assertStatus(400);
 	response.assertJSONSubset(
@@ -638,6 +641,7 @@ test('PUT /technologies/:id Updates technology with terms if terms[termSlug] is 
 
 test('PUT /technologies/:id does not update a technology if an inexistent term is provided', async ({
 	client,
+	assert,
 }) => {
 	const newTechnology = await Technology.create(technology);
 
@@ -648,6 +652,8 @@ test('PUT /technologies/:id does not update a technology if an inexistent term i
 		.loginVia(loggeduser, 'jwt')
 		.send({ terms: [99999] })
 		.end();
+
+	assert.equal(response.body.id, undefined);
 
 	response.assertStatus(400);
 	response.assertJSONSubset(

--- a/packages/api/test/functional/technology.spec.js
+++ b/packages/api/test/functional/technology.spec.js
@@ -283,15 +283,11 @@ test('POST /technologies creates/saves a new technology with users.', async ({ c
 		.send({ ...technology, users })
 		.end();
 
-	const technologyCreated = await Technology.find(response.body[0].id);
-
-	const technologyWithUsers = await Technology.query()
-		.with('users')
-		.where('id', technologyCreated.id)
-		.fetch();
+	const createdTechnology = await Technology.find(response.body.id);
+	await createdTechnology.load('users');
 
 	response.assertStatus(200);
-	response.assertJSONSubset(technologyWithUsers.toJSON());
+	response.assertJSONSubset(createdTechnology.toJSON());
 });
 
 test('POST /technologies creates/saves a new technology with terms', async ({ client }) => {
@@ -346,10 +342,8 @@ test('POST technologies/:idTechnology/users associates users with technology.', 
 		.send({ users })
 		.end();
 
-	const technologyWithUsers = await Technology.query()
-		.with('users')
-		.where('id', newTechnology.id)
-		.fetch();
+	const technologyWithUsers = await Technology.find(response.body.id);
+	await technologyWithUsers.load('users');
 
 	response.assertStatus(200);
 	response.assertJSONSubset(technologyWithUsers.toJSON());
@@ -416,10 +410,8 @@ test('PUT /technologies/:id Updates technology details with users', async ({ cli
 		.send({ ...updatedTechnology, users })
 		.end();
 
-	const technologyWithUsers = await Technology.query()
-		.with('users')
-		.where('id', newTechnology.id)
-		.fetch();
+	const technologyWithUsers = await Technology.find(response.body.id);
+	await technologyWithUsers.load('users');
 
 	response.assertStatus(200);
 	response.assertJSONSubset(technologyWithUsers.toJSON());

--- a/packages/api/test/functional/technology.spec.js
+++ b/packages/api/test/functional/technology.spec.js
@@ -459,7 +459,7 @@ test('PUT /technologies/:id Updates technology details with users', async ({ cli
 	response.assertJSONSubset(technologyWithUsers.toJSON());
 });
 
-test('PUT /technologies/:id trying update a technology with in a inexistent term.', async ({
+test('PUT /technologies/:id trying to update a technology with an inexistent term.', async ({
 	client,
 }) => {
 	const newTechnology = await Technology.create(technology);
@@ -503,8 +503,7 @@ test('PUT /technologies/:id Updates technology with a new term = termId in body'
 		.end();
 
 	response.assertStatus(200);
-	const technologyTerms = await newTechnology.terms().fetch();
-	newTechnology.terms = technologyTerms.toJSON();
+	await newTechnology.load('terms');
 	response.assertJSONSubset(newTechnology.toJSON());
 });
 
@@ -531,8 +530,7 @@ test('PUT /technologies/:id Updates technology with a new term = termSlug in bod
 		.end();
 
 	response.assertStatus(200);
-	const technologyTerms = await newTechnology.terms().fetch();
-	newTechnology.terms = technologyTerms.toJSON();
+	await newTechnology.load('terms');
 	response.assertJSONSubset(newTechnology.toJSON());
 });
 

--- a/packages/api/test/functional/technology.spec.js
+++ b/packages/api/test/functional/technology.spec.js
@@ -313,6 +313,48 @@ test('POST /technologies creates/saves a new technology with terms', async ({ cl
 	response.assertJSONSubset(createdTechnology.toJSON());
 });
 
+test('POST /technologies creates/saves a new technology with users and terms', async ({
+	client,
+}) => {
+	const loggedUser = await User.create(user);
+	const developerUser = await User.create({
+		email: 'sabiatestingdeveloper@gmail.com',
+		password: '123123',
+		first_name: 'FirstName',
+		last_name: 'LastName',
+	});
+
+	const users = [
+		{
+			userId: loggedUser.id,
+		},
+		{
+			userId: developerUser.id,
+			role: 'DEVELOPER',
+		},
+	];
+
+	const testTaxonomy = await Taxonomy.create(taxonomy);
+	const term1 = await testTaxonomy.terms().create({
+		term: 'TERM1',
+	});
+	const term2 = await testTaxonomy.terms().create({
+		term: 'TERM2',
+	});
+
+	const response = await client
+		.post('/technologies')
+		.loginVia(loggedUser, 'jwt')
+		.send({ ...technology, users, terms: [term1.id, term2.slug] })
+		.end();
+
+	const createdTechnology = await Technology.find(response.body.id);
+	await createdTechnology.loadMany(['users', 'terms']);
+
+	response.assertStatus(200);
+	response.assertJSONSubset(createdTechnology.toJSON());
+});
+
 /** POST technologies/:idTechnology/users */
 test('POST technologies/:idTechnology/users associates users with technology.', async ({
 	client,

--- a/packages/api/test/functional/technology.spec.js
+++ b/packages/api/test/functional/technology.spec.js
@@ -294,6 +294,29 @@ test('POST /technologies creates/saves a new technology with users.', async ({ c
 	response.assertJSONSubset(technologyWithUsers.toJSON());
 });
 
+test('POST /technologies creates/saves a new technology with terms', async ({ client }) => {
+	const loggedUser = await User.create(user);
+	const testTaxonomy = await Taxonomy.create(taxonomy);
+	const term1 = await testTaxonomy.terms().create({
+		term: 'TERM1',
+	});
+	const term2 = await testTaxonomy.terms().create({
+		term: 'TERM2',
+	});
+
+	const response = await client
+		.post('/technologies')
+		.loginVia(loggedUser, 'jwt')
+		.send({ ...technology, terms: [term1.id, term2.slug] })
+		.end();
+
+	const createdTechnology = await Technology.find(response.body.id);
+	await createdTechnology.load('terms');
+
+	response.assertStatus(200);
+	response.assertJSONSubset(createdTechnology.toJSON());
+});
+
 /** POST technologies/:idTechnology/users */
 test('POST technologies/:idTechnology/users associates users with technology.', async ({
 	client,

--- a/packages/api/test/unit/algolia.spec.js
+++ b/packages/api/test/unit/algolia.spec.js
@@ -6,13 +6,6 @@ trait('DatabaseTransactions');
 
 const TechnologyFaker = Factory.model('App/Models/Technology');
 
-test('algoliasearch.saveObject is called when creating a technology', async ({ assert }) => {
-	const technology = await TechnologyFaker.create();
-
-	assert.isTrue(AlgoliaSearch.initIndex.called);
-	assert.isTrue(AlgoliaSearch.initIndex().saveObject.withArgs(technology.toJSON()).calledOnce);
-});
-
 test('algoliasearch.deleteObject is called when destroying a technology', async ({ assert }) => {
 	const technology = await TechnologyFaker.create();
 	await technology.delete();


### PR DESCRIPTION
## Summary

<!-- Por favor, referencie a issue que esse PR se refere. -->
Resolves #148 

## Relevant technical choices
- A atualização dos `terms` de uma tecnologia funciona do mesmo modo que a atualização de `users` da tecnologia. Ou seja, sempre ocorre um detach de todos os terms e depois um attach de todos os terms. Ex.: se uma tecnologia tem os `terms` [1,2] e queremos deletar só 1 e inserir 2, deve ser enviada uma lista de terms [2,3]. 
- A indexação dos dados de tecnologia no algolia deixou de ser realizada dentro do hook `afterSave` do model `technology`. Isso porque, no momento em que o hook é executado, os `terms` associados à tecnologia ainda não estão na base de dados, não permitindo assim indexar a categoria (caso exista) da tecnologia no algolia. Essa indexação é feita (por enquanto) dentro do próprio controller.
- Agora a rota de atualização de tecnologias aceita um array de `terms` (e não mais um único `term`), assim como a rota de cadastro de tecnologia.
- O cadastro e atualização das tecnologias agora é feito em uma transação;

## Outros ajustes
- Foram realizados ajustes nas rotas das tecnologias que retormavam um array com 1 tecnologia para que retornassem um objeto, visto que o retorno esperado era sempre de uma única tecnologia;
- O campo `password` do model de `User` foi transformado em `hidden` para não ser retornado durante os fetchs;

## QA Steps
- Utilize a rota de cadastro de tecnologia (post `/technologies`) e envie um array com `terms` que possua slug e/ou id dos terms. **Insira pelo menos um dos termos da taxonomia de Categoria**. Ex.: `terms: ['Saneamento', 10]`. Em seguida:
  - Verifique no banco ( `technologies` e `technology_terms`) que os dados foram inseridos;
  - Verifique no algolia que a tecnologia foi inserida e existe um campo `category` que tem agora o term da taxonomia de categoria (nesse caso, `Saneamento`).
- Utilize a rota de cadastro de tecnologia e envie um array com `terms` que **não** seja da taxonomia de categoria **OU** sem os terms. Em seguida:
  - Verifique no banco ( `technologies` e `technology_terms`) que os dados foram inseridos; 
  - Verifique no algolia que a tecnologia foi inserida e existe um campo `category` que tem agora uma string padrão: "Não definida".
- Faça exatamene os testes acima porém utilizando a rota de **atualização da tecnologia** (put `/technologies/:id`)


<!-- Passos para testar essa PR (de preferência por um não-desenvolver) -->

## Checklist

- [X] My code is tested and passes existing unit tests.
- [X] My code has an appropriate set of unit tests which all pass.
- [X] My code passes the linting.
- [X] My code has proper inline documentation.
- [X] I have manually tested this PR.
