### PR TITLE
Custo de Implementação: R$ NaN

### DIFF
--- a/packages/web/__tests__/pages/t/__snapshots__/index.js.snap
+++ b/packages/web/__tests__/pages/t/__snapshots__/index.js.snap
@@ -848,7 +848,7 @@ exports[`Technology Details Page render correctly when user is logged in 1`] = `
   }
 }
 
-@media (max-width:768px) {
+@media (min-width:768px) {
   .c12 p {
     margin-right: 0.5rem;
   }
@@ -2436,7 +2436,7 @@ exports[`Technology Details Page render correctly when user is not logged in 1`]
   }
 }
 
-@media (max-width:768px) {
+@media (min-width:768px) {
   .c12 p {
     margin-right: 0.5rem;
   }

--- a/packages/web/__tests__/pages/t/index.js
+++ b/packages/web/__tests__/pages/t/index.js
@@ -41,7 +41,7 @@ describe('Technology Details Page', () => {
 		expect(container).toMatchSnapshot();
 	});
 
-	it('should not render `Custo de implantação` if technology has no cost', () => {
+	it('should not render implementation costs if the technology does not have it', () => {
 		jest.spyOn(useAuth, 'default').mockReturnValue({
 			user: {
 				email: 'test@test.com',

--- a/packages/web/__tests__/pages/t/index.js
+++ b/packages/web/__tests__/pages/t/index.js
@@ -40,4 +40,17 @@ describe('Technology Details Page', () => {
 
 		expect(container).toMatchSnapshot();
 	});
+
+	it('should not render `Custo de implantação` if technology has no cost', () => {
+		jest.spyOn(useAuth, 'default').mockReturnValue({
+			user: {
+				email: 'test@test.com',
+			},
+		});
+		const technologyNoCosts = { ...technology, technologyCosts: {} };
+
+		render(<Page technology={technologyNoCosts} relatedTechnologies={[technologyNoCosts]} />);
+
+		expect(screen.queryByText(/custo de implantação/i)).not.toBeInTheDocument();
+	});
 });

--- a/packages/web/components/Technology/Details/Header.js
+++ b/packages/web/components/Technology/Details/Header.js
@@ -147,7 +147,7 @@ export const ImplementationCost = styled.div`
 			text-transform: uppercase;
 			color: ${colors.black};
 
-			@media (max-width: ${screens.medium}px) {
+			@media (min-width: ${screens.medium}px) {
 				margin-right: 0.5rem;
 			}
 		}

--- a/packages/web/components/Technology/TechnologyProvider.js
+++ b/packages/web/components/Technology/TechnologyProvider.js
@@ -9,7 +9,7 @@ export const TechnologyProvider = ({ children, technology }) => {
 
 		const total = costs?.reduce((acc, item) => acc + item?.quantity * item?.value, 0);
 
-		return formatMoney(total);
+		return total ? formatMoney(total) : 0;
 	}, [technology]);
 
 	return (


### PR DESCRIPTION
## Summary

Resolves #424

## Relevant technical choices

Acabei optando por um ternário no return, pois caso costs seja um array vazio: `const costs = technology?.technologyCosts?.costs?.implementation_costs || [];`, o reduce retornaria 0, o que ocasionaria a situação:

![image](https://user-images.githubusercontent.com/13091635/93528948-84714f00-f911-11ea-9d29-8a8db8e0ecbf.png)

## QA Steps

* Acessar a página de qualquer tecnologia
* Tecnologias que não contém custos cadastrados não irão exibir o parágrafo `Custos de implantação` no cabeçalho:

![image](https://user-images.githubusercontent.com/13091635/93529171-dade8d80-f911-11ea-812d-4f71d06532e9.png)

## Checklist

- [X] My code is tested and passes existing unit tests.
- [X] My code has an appropriate set of unit tests which all pass.
- [X] My code passes the linting.
- [X] My code has proper inline documentation.
- [X] I have manually tested this PR.
