### PR TITLE
Fixes createUniqueSlug function

### DIFF
--- a/packages/api/app/Utils/slugify.js
+++ b/packages/api/app/Utils/slugify.js
@@ -19,8 +19,8 @@ const createUniqueSlug = async (model, propertyToBeSlugfied, slugColumn = 'slug'
 
 	const slugStoredPreviously = await model
 		.query()
-		.where(slugColumn, 'REGEXP', `^${slug}.*(-(d*))?$`)
-		.orderBy(slugColumn, 'desc')
+		.where(slugColumn, 'LIKE', `${slug}%`)
+		.orderByRaw(`substring(${slugColumn},length('${slug}-'))*1`)
 		.first();
 
 	if (slugStoredPreviously) {

--- a/packages/api/test/unit/slugify.spec.js
+++ b/packages/api/test/unit/slugify.spec.js
@@ -1,6 +1,11 @@
 /* eslint-disable func-names */
-const { test } = use('Test/Suite')('Slugify');
+const { test, trait } = use('Test/Suite')('Slugify');
 const { createUniqueSlug, incrementSlugSuffix } = require('../../app/Utils/slugify');
+
+const Term = use('App/Models/Term');
+const Technology = use('App/Models/Technology');
+
+trait('DatabaseTransactions');
 
 function StubModel(first = null) {
 	this.query = function() {
@@ -10,6 +15,9 @@ function StubModel(first = null) {
 		return this;
 	};
 	this.orderBy = function() {
+		return this;
+	};
+	this.orderByRaw = function() {
 		return this;
 	};
 	this.first = function() {
@@ -52,4 +60,53 @@ test('add the suffix using the last part of the slug + 1 regardless of suffix va
 test('add the first suffix when does not have suffix', async ({ assert }) => {
 	const mySlugWithouSuffix = incrementSlugSuffix('new-slug');
 	assert.equal(mySlugWithouSuffix, 'new-slug-1');
+});
+
+test('tests unique slugs in multiple term creation', async ({ assert }) => {
+	const terms = [];
+
+	for (let i = 0; i < 20; i += 1) {
+		terms.push({
+			term: 'Test Term',
+		});
+	}
+	const termInstances = await Term.createMany(terms);
+
+	assert.equal(termInstances[0].slug, 'test-term');
+
+	termInstances.forEach((term, index) => {
+		if (index > 0) assert.equal(term.slug, `test-term-${index}`);
+	});
+});
+
+test('tests unique slugs in multiple technology creation', async ({ assert }) => {
+	const technologies = [];
+
+	for (let i = 0; i < 20; i += 1) {
+		technologies.push({
+			title: 'Test Technology Title',
+			description: 'Test description',
+			private: 1,
+			intellectual_property: 1,
+			patent: 1,
+			patent_number: '0001/2020',
+			primary_purpose: 'Test primary purpose',
+			secondary_purpose: 'Test secondary purpose',
+			application_mode: 'Test application mode',
+			application_examples: 'Test application example',
+			installation_time: 365,
+			solves_problem: 'Solves problem test',
+			entailes_problem: 'Entailes problem test',
+			requirements: 'Requirements test',
+			risks: 'Test risks',
+			contribution: 'Test contribution',
+		});
+	}
+	const technologyInstances = await Technology.createMany(technologies);
+
+	assert.equal(technologyInstances[0].slug, 'test-technology-title');
+
+	technologyInstances.forEach((technology, index) => {
+		if (index > 0) assert.equal(technology.slug, `test-technology-title-${index}`);
+	});
 });


### PR DESCRIPTION
## Summary

Resolves #514

## Relevant technical choices

Usei o `orderByRaw` porque o `orderBy` nativo só aceita uma coluna e não uma experssão.

```javascript 
const slugStoredPreviously = await model
		.query()
		.where(slugColumn, 'LIKE', `${slug}%`)
		.orderByRaw(`substring(${slugColumn},length('${slug}-'))*1`)
		.first();
```

## QA Steps

Dois novos testes foram incluidos no testes unitários do slugify, para testar essa PR:

`adonis test --files test/unit/slugify.spec.js `

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
