### PR TITLE
Ajustar macro withParams para receber option e não efetuar o relacionamento

### DIFF
--- a/packages/api/app/Controllers/Http/TaxonomyController.js
+++ b/packages/api/app/Controllers/Http/TaxonomyController.js
@@ -17,7 +17,7 @@ class TaxonomyController {
 		return Taxonomy.query()
 			.with('terms')
 			.withFilters(filters)
-			.withParams(request);
+			.withParams(request, { skipRelationship: ['terms'] });
 	}
 
 	/**

--- a/packages/api/app/Controllers/Http/TaxonomyController.js
+++ b/packages/api/app/Controllers/Http/TaxonomyController.js
@@ -17,7 +17,7 @@ class TaxonomyController {
 		return Taxonomy.query()
 			.with('terms')
 			.withFilters(filters)
-			.withParams(request, { skipRelationship: ['terms'] });
+			.withParams(request, { skipRelationships: ['terms'] });
 	}
 
 	/**

--- a/packages/api/app/Controllers/Http/TechnologyController.js
+++ b/packages/api/app/Controllers/Http/TechnologyController.js
@@ -81,7 +81,7 @@ class TechnologyController {
 					builder.where('id', technology.id);
 				})
 				.where('taxonomy_id', taxonomy.id)
-				.withParams(request, { filterById: false, skipRelationship: ['technologies'] });
+				.withParams(request, { filterById: false, skipRelationships: ['technologies'] });
 		}
 
 		return Term.query()

--- a/packages/api/app/Controllers/Http/TechnologyController.js
+++ b/packages/api/app/Controllers/Http/TechnologyController.js
@@ -81,7 +81,7 @@ class TechnologyController {
 					builder.where('id', technology.id);
 				})
 				.where('taxonomy_id', taxonomy.id)
-				.withParams(request, { filterById: false });
+				.withParams(request, { filterById: false, skipRelationship: ['technologies'] });
 		}
 
 		return Term.query()

--- a/packages/api/app/Models/Traits/Params.js
+++ b/packages/api/app/Models/Traits/Params.js
@@ -63,11 +63,11 @@ class Params {
 			// eslint-disable-next-line no-underscore-dangle
 			const resource = this._single.table;
 
-			const { filterById = true, skipRelationship = [] } = options;
+			const { filterById = true, skipRelationships = [] } = options;
 
 			if (embed.all) {
 				relationships[resource].map(
-					(model) => !skipRelationship.includes(model) && this.with(model),
+					(model) => !skipRelationships.includes(model) && this.with(model),
 				);
 			} else if (embed.ids) {
 				relationships[resource].map((model) =>

--- a/packages/api/app/Models/Traits/Params.js
+++ b/packages/api/app/Models/Traits/Params.js
@@ -57,18 +57,17 @@ class Params {
 			],
 		};
 
-		Model.queryMacro('withParams', async function withParams(
-			request,
-			options = { filterById: true, skipRelationship: [] },
-		) {
+		Model.queryMacro('withParams', async function withParams(request, options = {}) {
 			const { id, embed, page, perPage, order, orderBy, ids, notIn } = request.params;
 
 			// eslint-disable-next-line no-underscore-dangle
 			const resource = this._single.table;
 
+			const { filterById = true, skipRelationship = [] } = options;
+
 			if (embed.all) {
 				relationships[resource].map(
-					(model) => !options.skipRelationship.includes(model) && this.with(model),
+					(model) => !skipRelationship.includes(model) && this.with(model),
 				);
 			} else if (embed.ids) {
 				relationships[resource].map((model) =>
@@ -77,9 +76,9 @@ class Params {
 			}
 
 			const isIdInteger = Number.isInteger(Number(id));
-			if (id && isIdInteger && options.filterById) {
+			if (id && isIdInteger && filterById) {
 				this.where({ id });
-			} else if (typeof id === 'undefined' || id === false || !options.filterById) {
+			} else if (typeof id === 'undefined' || id === false || !filterById) {
 				if (ids) {
 					this.whereIn('id', ids);
 				}

--- a/packages/api/app/Models/Traits/Params.js
+++ b/packages/api/app/Models/Traits/Params.js
@@ -59,7 +59,7 @@ class Params {
 
 		Model.queryMacro('withParams', async function withParams(
 			request,
-			options = { filterById: true },
+			options = { filterById: true, skipRelationship: [] },
 		) {
 			const { id, embed, page, perPage, order, orderBy, ids, notIn } = request.params;
 
@@ -67,7 +67,9 @@ class Params {
 			const resource = this._single.table;
 
 			if (embed.all) {
-				relationships[resource].map((model) => this.with(model));
+				relationships[resource].map(
+					(model) => !options.skipRelationship.includes(model) && this.with(model),
+				);
 			} else if (embed.ids) {
 				relationships[resource].map((model) =>
 					this.with(model, (builder) => builder.select('id')),

--- a/packages/api/test/functional/taxonomy.spec.js
+++ b/packages/api/test/functional/taxonomy.spec.js
@@ -45,7 +45,7 @@ test('GET taxonomies and single taxonomy with embed and parent', async ({ client
 					embed: { all: true, ids: false },
 				},
 			},
-			{ skipRelationship: ['terms'] },
+			{ skipRelationships: ['terms'] },
 		);
 
 	let response = await client.get('/taxonomies?embed&parent=0').end();

--- a/packages/api/test/functional/taxonomy.spec.js
+++ b/packages/api/test/functional/taxonomy.spec.js
@@ -38,12 +38,15 @@ test('GET taxonomies and single taxonomy with embed and parent', async ({ client
 	// all taxonomies with embedding containing only parent terms.
 	let taxonomies = await Taxonomy.query()
 		.withFilters({ parent: 0 })
-		.withParams({
-			params: {
-				...defaultParams,
-				embed: { all: true, ids: false },
+		.withParams(
+			{
+				params: {
+					...defaultParams,
+					embed: { all: true, ids: false },
+				},
 			},
-		});
+			{ skipRelationship: ['terms'] },
+		);
 
 	let response = await client.get('/taxonomies?embed&parent=0').end();
 


### PR DESCRIPTION
## Summary

Resolves #534

## Relevant technical choices

* Adicionei uma nova option no withParams, `skipRelationship`. Essa option permite excluir um relacionamento do `embed`, pois estava sobrescrevendo o `withFilters`

## QA Steps

* Executar testes funcionais

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
