### PR TITLE
Technology Form - Quantity field is not a number

### DIFF
--- a/packages/web/components/TechnologyForm/Costs/CostsTable.js
+++ b/packages/web/components/TechnologyForm/Costs/CostsTable.js
@@ -75,9 +75,11 @@ const CostsTable = ({ item, index, form, remove, collection }) => {
 							required: true,
 							pattern: {
 								value: /^[0-9]*$/,
-								message: 'Você deve digitar apenas números',
+								message: 'Você deve digitar apenas números positivos',
 							},
 						}}
+						type="number"
+						min="0"
 					/>
 				</Cell>
 				<Cell>


### PR DESCRIPTION
## Summary

Resolves #563

## QA Steps

1. Access costs step in technology edit form
2. Quantity field must only accept positive numbers
3. Validation message should show if number is negative 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
