### PR TITLE
Includes new fields in Technology Cost Schema

### DIFF
--- a/packages/api/app/Controllers/Http/TechnologyCostController.js
+++ b/packages/api/app/Controllers/Http/TechnologyCostController.js
@@ -11,6 +11,8 @@ const getFields = (request) =>
 		'funding_value',
 		'funding_status',
 		'notes',
+		'is_seller',
+		'price',
 		'costs',
 	]);
 

--- a/packages/api/app/Validators/UpdateTechnologyCost.js
+++ b/packages/api/app/Validators/UpdateTechnologyCost.js
@@ -3,6 +3,8 @@ const BaseValidator = use('App/Validators/BaseValidator');
 class UpdateTechnologyCost extends BaseValidator {
 	get rules() {
 		return {
+			is_seller: 'required|boolean',
+			price: 'required_when:is_seller,true|required_when:is_seller,1',
 			costs: 'array',
 			'costs.*.id': 'number|exists:costs,id',
 			'costs.*.cost_type': 'string',
@@ -10,6 +12,7 @@ class UpdateTechnologyCost extends BaseValidator {
 			'costs.*.type': 'string',
 			'costs.*.quantity': 'number',
 			'costs.*.value': 'number',
+			'costs.*.measure_unit': 'string',
 		};
 	}
 }

--- a/packages/api/database/factory.js
+++ b/packages/api/database/factory.js
@@ -76,6 +76,8 @@ Factory.blueprint('App/Models/TechnologyCost', async (faker) => {
 		funding_value: faker.integer({ min: 10, max: 100000000 }),
 		funding_status: faker.pickone(['not_acquired', 'acquiring', 'acquired']),
 		notes: faker.paragraph(),
+		is_seller: faker.bool(),
+		price: faker.integer({ min: 10, max: 100000000 }),
 	};
 });
 
@@ -90,6 +92,7 @@ Factory.blueprint('App/Models/Cost', async (faker) => {
 		type: faker.pickone(['service', 'equipment', 'others', 'raw_input']),
 		quantity: faker.integer({ min: 1, max: 100 }),
 		value: faker.integer({ min: 10, max: 100000000 }),
+		measure_unit: faker.string({ length: 2 }),
 	};
 });
 

--- a/packages/api/database/migrations/1604445504091_technology_cost_add_is_seller_price_schema.js
+++ b/packages/api/database/migrations/1604445504091_technology_cost_add_is_seller_price_schema.js
@@ -1,0 +1,23 @@
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema');
+
+class TechnologyCostAddIsSellerPriceSchema extends Schema {
+	up() {
+		this.table('technology_costs', (table) => {
+			table
+				.boolean('is_seller')
+				.notNullable()
+				.defaultTo(1);
+			table.integer('price');
+		});
+	}
+
+	down() {
+		this.table('technology_costs', (table) => {
+			table.dropColumn('is_seller');
+			table.dropColumn('price');
+		});
+	}
+}
+
+module.exports = TechnologyCostAddIsSellerPriceSchema;

--- a/packages/api/database/migrations/1604445819985_cost_measure_unit_schema.js
+++ b/packages/api/database/migrations/1604445819985_cost_measure_unit_schema.js
@@ -1,0 +1,21 @@
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema');
+
+class CostMeasureUnitSchema extends Schema {
+	up() {
+		this.table('costs', (table) => {
+			table
+				.string('measure_unit')
+				.notNullable()
+				.defaultTo('');
+		});
+	}
+
+	down() {
+		this.table('costs', (table) => {
+			table.dropColumn('measure_unit');
+		});
+	}
+}
+
+module.exports = CostMeasureUnitSchema;

--- a/packages/api/test/functional/technology-cost.spec.js
+++ b/packages/api/test/functional/technology-cost.spec.js
@@ -38,6 +38,8 @@ const technologyCost = {
 	funding_value: 200000000,
 	funding_status: 'approved',
 	notes: 'some additional information',
+	is_seller: true,
+	price: 1000000000,
 	costs: [
 		{
 			cost_type: 'development_costs',
@@ -45,6 +47,7 @@ const technologyCost = {
 			type: 'material',
 			quantity: 1,
 			value: 10000,
+			measure_unit: 'm',
 		},
 		{
 			cost_type: 'implementation_costs',
@@ -52,6 +55,7 @@ const technologyCost = {
 			type: 'service',
 			quantity: 1,
 			value: 10000,
+			measure_unit: 'kg',
 		},
 		{
 			cost_type: 'maintenance_costs',
@@ -59,6 +63,7 @@ const technologyCost = {
 			type: 'material',
 			quantity: 2,
 			value: 5000,
+			measure_unit: 'kg',
 		},
 	],
 };
@@ -91,6 +96,7 @@ test('PUT /technologies/:id/costs creates/saves a new technology cost.', async (
 	const technologyCostCreated = await TechnologyCost.find(response.body.id);
 	await technologyCostCreated.load('costs');
 	technologyCostCreated.funding_required = true;
+	technologyCostCreated.is_seller = true;
 
 	response.assertStatus(200);
 	response.assertJSONSubset(technologyCostCreated.toJSON());
@@ -108,6 +114,7 @@ test('PUT /technologies/:id/costs update technology cost details.', async ({ cli
 		funding_value: 10000000,
 		funding_status: 'pending',
 		notes: 'updated notes information',
+		is_seller: false,
 	};
 
 	const response = await client


### PR DESCRIPTION
## Summary

Resolves #581 

## Relevant technical choices

Cria os campos em technology_costs_schema:
`is_seller`: Você é o vendedor dessa tecnologia?
`price`: Preço da tecnologia
Cria o campo em costs_schema:
`measure_unit`: Unidade de Medida
**No front criar um select com todos as unidades de medidas conhecidas e enviar esse campo como string no array de `costs`**

## QA Steps

Rodar os testes.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
- [ ] My code is documented by ApiDoc.
