### PR TITLE
Corrigir o z-index do slider

### DIFF
--- a/packages/web/__tests__/pages/t/__snapshots__/index.js.snap
+++ b/packages/web/__tests__/pages/t/__snapshots__/index.js.snap
@@ -408,7 +408,7 @@ exports[`Technology Details Page render correctly when user is logged in 1`] = `
   width: 34px;
   height: 34px;
   position: absolute;
-  z-index: 10000;
+  z-index: 1;
   border-radius: 50%;
   background-color: hsl(0deg 0% 0% / 17%);
   color: hsla(0,0%,100%);
@@ -2042,7 +2042,7 @@ exports[`Technology Details Page render correctly when user is not logged in 1`]
   width: 34px;
   height: 34px;
   position: absolute;
-  z-index: 10000;
+  z-index: 1;
   border-radius: 50%;
   background-color: hsl(0deg 0% 0% / 17%);
   color: hsla(0,0%,100%);

--- a/packages/web/components/Technology/Details/ImagesCarousel/styles.js
+++ b/packages/web/components/Technology/Details/ImagesCarousel/styles.js
@@ -16,7 +16,7 @@ export const CarouselContainer = styled(Slider)`
 			width: 34px;
 			height: 34px;
 			position: absolute;
-			z-index: 10000;
+			z-index: 1;
 			border-radius: 50%;
 			background-color: ${colors.lightWhite2};
 			color: ${colors.white};


### PR DESCRIPTION
## Summary

Resolves #549 

## Relevant technical choices

* Changed `z-index` to 1. It's enough to keep the arrows in front of the image.

## QA Steps

1. Access any technology details page which has custom images
2. Open the register modal
3. The arrows of images carousel must not overlap modal overlay

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
