### PR TITLE
Integrate contact us page with API

### DIFF
--- a/packages/web/__tests__/pages/t/__snapshots__/index.js.snap
+++ b/packages/web/__tests__/pages/t/__snapshots__/index.js.snap
@@ -408,7 +408,7 @@ exports[`Technology Details Page render correctly when user is logged in 1`] = `
   width: 34px;
   height: 34px;
   position: absolute;
-  z-index: 10000;
+  z-index: 1;
   border-radius: 50%;
   background-color: hsl(0deg 0% 0% / 17%);
   color: hsla(0,0%,100%);
@@ -2042,7 +2042,7 @@ exports[`Technology Details Page render correctly when user is not logged in 1`]
   width: 34px;
   height: 34px;
   position: absolute;
-  z-index: 10000;
+  z-index: 1;
   border-radius: 50%;
   background-color: hsl(0deg 0% 0% / 17%);
   color: hsla(0,0%,100%);

--- a/packages/web/components/Technology/Details/ImagesCarousel/styles.js
+++ b/packages/web/components/Technology/Details/ImagesCarousel/styles.js
@@ -16,7 +16,7 @@ export const CarouselContainer = styled(Slider)`
 			width: 34px;
 			height: 34px;
 			position: absolute;
-			z-index: 10000;
+			z-index: 1;
 			border-radius: 50%;
 			background-color: ${colors.lightWhite2};
 			color: ${colors.white};

--- a/packages/web/services/contact.js
+++ b/packages/web/services/contact.js
@@ -1,0 +1,17 @@
+/* eslint-disable import/prefer-default-export */
+
+import { apiPost } from './api';
+
+/**
+ * Sends an e-mail message to the platform admin
+ *
+ * @param {object} values The fields value to send to API
+ * @returns {void}
+ */
+export const sendContactMail = async (values = {}) => {
+	const response = await apiPost('contact', { ...values });
+
+	if (response.status !== 204) return false;
+
+	return true;
+};

--- a/packages/web/services/index.js
+++ b/packages/web/services/index.js
@@ -6,3 +6,4 @@ export * from './technology';
 export * from './user';
 export * from './terms';
 export * from './reviewer';
+export * from './contact';


### PR DESCRIPTION
## Summary

Resolves #609

https://www.loom.com/share/6b87a451498b44eb8cfe54fc05782a1e

## Relevant technical choices

* Had to add a method to handle phone number mask when it has 9 digits.

## QA Steps

**The API isn't merged yet. I've tested using `ngrok` doing pair programming with @mateus4k**

1. Access contact us page
2. Fill all fields
3. Click send button
4. Request sent success modal should be shown

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
