### PR TITLE
Fix duplicated Google Maps API 

### DIFF
--- a/packages/web/components/GoogleMaps/index.js
+++ b/packages/web/components/GoogleMaps/index.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import { Map as GoogleMap, GoogleApiWrapper, Marker } from 'google-maps-react';
+import { Map as GoogleMap, Marker } from 'google-maps-react';
 import PropTypes from 'prop-types';
 import TechonologyEnums from '../../utils/enums/technology.enums';
-import config from '../../config';
-
-const apiKey = config.GOOGLE_MAPS_KEY;
 
 export const getMarkerIconByTerm = new Map([
 	[TechonologyEnums.WHO_DEVELOP, '/google-map-marker-icon.png'],
@@ -12,7 +9,9 @@ export const getMarkerIconByTerm = new Map([
 	[TechonologyEnums.WHERE_CAN_BE_APPLIED, '/google-map-marker-icon-3.png'],
 ]);
 
-const MapContainer = ({ google, markers }) => {
+const MapContainer = ({ markers }) => {
+	const google = typeof window !== 'undefined' && window.google;
+
 	return (
 		<GoogleMap
 			google={google}
@@ -22,7 +21,8 @@ const MapContainer = ({ google, markers }) => {
 				lng: -36.702823,
 			}}
 		>
-			{markers &&
+			{google &&
+				markers &&
 				markers.map((marker) => {
 					return (
 						<Marker
@@ -42,12 +42,6 @@ const MapContainer = ({ google, markers }) => {
 };
 
 MapContainer.propTypes = {
-	google: PropTypes.shape({
-		maps: PropTypes.shape({
-			Point: PropTypes.func,
-			Size: PropTypes.func,
-		}),
-	}).isRequired,
 	markers: PropTypes.arrayOf(
 		PropTypes.shape({
 			description: PropTypes.string,
@@ -61,6 +55,4 @@ MapContainer.defaultProps = {
 	markers: [],
 };
 
-export default GoogleApiWrapper({
-	apiKey,
-})(MapContainer);
+export default MapContainer;

--- a/packages/web/components/head.js
+++ b/packages/web/components/head.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import NextHead from 'next/head';
 import PropTypes from 'prop-types';
-import config from '../config';
 
 const Head = ({ title, description, url, ogImage }) => (
 	<NextHead>
@@ -22,9 +21,6 @@ const Head = ({ title, description, url, ogImage }) => (
 		<meta property="og:image" content={ogImage} key="og:image" />
 		<meta property="og:image:width" content="1200" key="og:image:width" />
 		<meta property="og:image:height" content="630" key="og:image:height" />
-		<script
-			src={`https://maps.googleapis.com/maps/api/js?key=${config.GOOGLE_MAPS_KEY}&libraries=places`}
-		/>
 	</NextHead>
 );
 

--- a/packages/web/pages/_app.js
+++ b/packages/web/pages/_app.js
@@ -3,6 +3,7 @@ import React from 'react';
 import App from 'next/app';
 import cookies from 'next-cookies';
 import Router from 'next/router';
+import NextHead from 'next/head';
 import NProgress from 'nprogress'; // nprogress module
 import { ThemeProvider, GlobalStyle } from '../styles';
 import Layout from '../components/layout';
@@ -49,23 +50,30 @@ export class SabiaApp extends App {
 		`;
 
 		return (
-			<ThemeProvider>
-				<script
-					key="script/pre-init"
-					type="application/javascript"
-					// eslint-disable-next-line react/no-danger
-					dangerouslySetInnerHTML={{ __html: loadEnvConfig }}
-				/>
-				<GlobalStyle />
-				<ToastContainer />
-				<UserProvider user={user || {}}>
-					<ModalProvider>
-						<Layout>
-							<Component {...pageProps} />
-						</Layout>
-					</ModalProvider>
-				</UserProvider>
-			</ThemeProvider>
+			<>
+				<NextHead>
+					<script
+						src={`https://maps.googleapis.com/maps/api/js?key=${config.GOOGLE_MAPS_KEY}&libraries=places`}
+					/>
+				</NextHead>
+				<ThemeProvider>
+					<script
+						key="script/pre-init"
+						type="application/javascript"
+						// eslint-disable-next-line react/no-danger
+						dangerouslySetInnerHTML={{ __html: loadEnvConfig }}
+					/>
+					<GlobalStyle />
+					<ToastContainer />
+					<UserProvider user={user || {}}>
+						<ModalProvider>
+							<Layout>
+								<Component {...pageProps} />
+							</Layout>
+						</ModalProvider>
+					</UserProvider>
+				</ThemeProvider>
+			</>
 		);
 	}
 }


### PR DESCRIPTION
## Summary

Resolves #423 

## Relevant technical choices

Had to remove Maps API `<script />` tag from `<Head />` component as it's used in some pages: search and technology details. This causes the multiple injection of the api as `<Head />` is rendered many times.

Also had to change `<GoogleMaps />` component to use google object that was previous injected, so it doesn't inject the api again.

## QA Steps

1. Access technology register form in Maps step. Places autocomplete must work properly
2. Access technology register form in review step, using SSR (refresh the page). Maps must be shown.
3. Open your console. You must not receive duplicated maps API error.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
