### PR TITLE
Disclaimers de conflito de interesse 

### DIFF
--- a/packages/api/app/Utils/statuses.js
+++ b/packages/api/app/Utils/statuses.js
@@ -36,10 +36,18 @@ const orderStatuses = {
 	CANCELED: 'canceled',
 };
 
+const disclaimersTypes = {
+	PRIVACYPOLICY: 'privacypolicy',
+	REGISTER: 'register',
+	TECHNOLOGY: 'technology',
+	REVIEWERS: 'reviewers',
+};
+
 module.exports = {
 	technologyStatuses,
 	reviewerStatuses,
 	technologyUseStatuses,
 	fundingStatuses,
 	orderStatuses,
+	disclaimersTypes,
 };

--- a/packages/api/app/Validators/Disclaimer.js
+++ b/packages/api/app/Validators/Disclaimer.js
@@ -1,11 +1,12 @@
 const BaseValidator = use('App/Validators/BaseValidator');
+const { disclaimersTypes } = require('../Utils');
 
 class Disclaimer extends BaseValidator {
 	get rules() {
 		return {
 			description: 'required|string',
 			required: 'required|boolean',
-			type: 'in:privacypolicy,termsOfUseRegister,termsOfUseTechnology',
+			type: `required|string|in:${Object.values(disclaimersTypes).join()}`,
 			version: 'required|string',
 		};
 	}

--- a/packages/api/database/factory.js
+++ b/packages/api/database/factory.js
@@ -10,7 +10,7 @@
 */
 /** @type {import('@adonisjs/lucid/src/Factory')} */
 const Factory = use('Factory');
-const { technologyStatuses } = require('../app/Utils');
+const { technologyStatuses, disclaimersTypes } = require('../app/Utils');
 
 Factory.blueprint('App/Models/User', async (faker) => {
 	return {
@@ -119,5 +119,14 @@ Factory.blueprint('App/Models/Institution', async (faker) => {
 		state: faker.state(),
 		lat: String(faker.latitude()),
 		lng: String(faker.longitude()),
+	};
+});
+
+Factory.blueprint('App/Models/Disclaimer', async (faker) => {
+	return {
+		description: faker.sentence({ words: 10 }),
+		required: faker.integer({ min: 0, max: 1 }),
+		type: faker.pickone(Object.values(disclaimersTypes)),
+		version: faker.string({ length: 5 }),
 	};
 });

--- a/packages/api/database/migrations/1605981580411_refactor_disclaimers_status_schema.js
+++ b/packages/api/database/migrations/1605981580411_refactor_disclaimers_status_schema.js
@@ -17,7 +17,10 @@ class RefactorDisclaimersStatusSchema extends Schema {
 	down() {
 		this.alter('disclaimers', (table) => {
 			// reverse alternations
-			table.dropColumn('type');
+			table
+				.enu('type', ['privacypolicy', 'termsOfUseRegister', 'termsOfUseTechnology'])
+				.notNullable()
+				.alter();
 		});
 	}
 }

--- a/packages/api/database/migrations/1605981580411_refactor_disclaimers_status_schema.js
+++ b/packages/api/database/migrations/1605981580411_refactor_disclaimers_status_schema.js
@@ -17,10 +17,7 @@ class RefactorDisclaimersStatusSchema extends Schema {
 	down() {
 		this.alter('disclaimers', (table) => {
 			// reverse alternations
-			table
-				.enu('type', ['privacypolicy', 'termsOfUseRegister', 'termsOfUseTechnology'])
-				.notNullable()
-				.alter();
+			table.dropColumn('type');
 		});
 	}
 }

--- a/packages/api/database/migrations/1605981580411_refactor_disclaimers_status_schema.js
+++ b/packages/api/database/migrations/1605981580411_refactor_disclaimers_status_schema.js
@@ -1,0 +1,25 @@
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema');
+const { disclaimersTypes } = require('../../app/Utils');
+
+class RefactorDisclaimersStatusSchema extends Schema {
+	up() {
+		this.alter('disclaimers', (table) => {
+			// alter table
+			table
+				.enu('type', Object.values(disclaimersTypes))
+				.defaultTo(disclaimersTypes.PRIVACYPOLICY)
+				.notNullable()
+				.alter();
+		});
+	}
+
+	down() {
+		this.alter('disclaimers', (table) => {
+			// reverse alternations
+			table.dropColumn('type');
+		});
+	}
+}
+
+module.exports = RefactorDisclaimersStatusSchema;

--- a/packages/api/database/seeds/10_DisclaimerSeeder.js
+++ b/packages/api/database/seeds/10_DisclaimerSeeder.js
@@ -18,77 +18,77 @@ class DisclaimerSeeder {
 				description:
 					'Concordo com a Política de Privacidade e os Termos e Condições de Uso.',
 				required: true,
-				type: 'termsOfUseRegister',
+				type: 'register',
 				version: '1',
 			},
 			{
 				description:
 					'Concordo com o processamento dos meus dados pessoais para fins de fornecimento dos serviços da Plataforma Sabiá.  ',
 				required: true,
-				type: 'termsOfUseRegister',
+				type: 'register',
 				version: '1',
 			},
 			{
 				description:
 					'Concordo em respeitar a legislação brasileira vigente no conteúdo que eu venha a disponibilizar na Plataforma Sabiá, sendo de minha exclusiva responsabilidade.  ',
 				required: true,
-				type: 'termsOfUseRegister',
+				type: 'register',
 				version: '1',
 			},
 			{
 				description:
 					'Estou ciente de que posso revogar o consentimento de uso dos meus dados pessoais a qualquer momento. Todavia, não poderei mais utilizar os serviços da plataforma que necessitam do uso e da coleta de dados pessoais.  ',
 				required: true,
-				type: 'termsOfUseRegister',
+				type: 'register',
 				version: '1',
 			},
 			{
 				description:
 					'Estou ciente quanto ao canal de suporte da Plataforma Sabiá, que estará à disposição para sanar eventual dúvida que possa surgir.',
 				required: true,
-				type: 'termsOfUseRegister',
+				type: 'register',
 				version: '1',
 			},
 			{
 				description:
 					'Estou ciente que em hipótese alguma será constituído vínculo cooperativo, associativo, societário ou empregatício entre a plataforma, os usuários cadastrados e os parceiros. ',
 				required: true,
-				type: 'termsOfUseRegister',
+				type: 'register',
 				version: '1',
 			},
 			{
 				description:
 					'Concordo com o processamento dos meus dados pessoais com o objetivo de receber publicidade da Plataforma Sabiá e de terceiros parceiros. ',
 				required: true,
-				type: 'termsOfUseRegister',
+				type: 'register',
 				version: '1',
 			},
 			{
 				description:
 					'Declaro ciência de que devo fornecer apenas informações verdadeiras no cadastro das tecnologias. ',
 				required: true,
-				type: 'termsOfUseTechnology',
+				type: 'technology',
 				version: '1',
 			},
 			{
 				description:
 					'Estou ciente de que as informações cadastradas são de minha inteira responsabilidade, e a Plataforma Sabiá não responderá por quaisquer violações ao Direito de Propriedade Intelectual e Direito Autoral de terceiros. ',
 				required: true,
-				type: 'termsOfUseTechnology',
+				type: 'technology',
 				version: '1',
 			},
 			{
 				description:
 					'Estou ciente de que poderei ser penalizado com advertência, suspensão e encerramento da minha conta por eventuais violações a direitos de terceiros no cadastro das tecnologias, como o Direito de Propriedade Intelectual e Direito Autoral. ',
 				required: true,
-				type: 'termsOfUseTechnology',
+				type: 'technology',
 				version: '1',
 			},
 			{
 				description:
 					'Declaro ciência de que as transgressões a direitos de terceiros no cadastro das tecnologias podem implicar em responsabilização na esfera jurisdicional cível e criminal. ',
 				required: true,
-				type: 'termsOfUseTechnology',
+				type: 'technology',
 				version: '1',
 			},
 
@@ -96,21 +96,21 @@ class DisclaimerSeeder {
 				description:
 					'Declaro estar disponível para avaliar as informações cadastradas pelos usuários no cadastro de tecnologias, checar sua coerência e consistência, bem como analisar o nível das tecnologias cadastradas na Plataforma Sabiá, desde que estejam dentro da minha área de especialidade.',
 				required: true,
-				type: 'termsOfUseReviewers',
+				type: 'reviewers',
 				version: '1',
 			},
 			{
 				description:
 					'Declaro que NÃO POSSUO conflito de interesses de ordens financeira, comercial, política, acadêmica e pessoal com as tecnologias pela qual irei avaliar.',
 				required: true,
-				type: 'termsOfUseReviewers',
+				type: 'reviewers',
 				version: '1',
 			},
 			{
 				description:
 					'Declaro que irei atender aos princípios éticos no uso da Plataforma Sabiá e desempenharei as minhas funções com probidade, boa-fé e de acordo com a legislação vigente, sendo inteiramente responsável pelas condutas lesivas a direitos de terceiros, ao próprio serviço disponibilizado pela plataforma e à Administração Pública, com responsabilização civil contratual e/ou extracontratual e adoção das medidas penais aplicáveis ao caso, conforme os Termos e Condições de Uso.',
 				required: true,
-				type: 'termsOfUseReviewers',
+				type: 'reviewers',
 				version: '1',
 			},
 		]);
@@ -121,9 +121,9 @@ class DisclaimerSeeder {
 
 		await Promise.all(
 			users.rows.map((user) => {
-				user.acceptMandatory('termsOfUseRegister');
-				user.acceptMandatory('termsOfUseTechnology');
-				user.acceptMandatory('termsOfUseReviewers');
+				user.acceptMandatory('register');
+				user.acceptMandatory('technology');
+				user.acceptMandatory('reviewers');
 				return user;
 			}),
 		);

--- a/packages/api/database/seeds/10_DisclaimerSeeder.js
+++ b/packages/api/database/seeds/10_DisclaimerSeeder.js
@@ -91,6 +91,28 @@ class DisclaimerSeeder {
 				type: 'termsOfUseTechnology',
 				version: '1',
 			},
+
+			{
+				description:
+					'Declaro estar disponível para avaliar as informações cadastradas pelos usuários no cadastro de tecnologias, checar sua coerência e consistência, bem como analisar o nível das tecnologias cadastradas na Plataforma Sabiá, desde que estejam dentro da minha área de especialidade.',
+				required: true,
+				type: 'termsOfUseReviewers',
+				version: '1',
+			},
+			{
+				description:
+					'Declaro que NÃO POSSUO conflito de interesses de ordens financeira, comercial, política, acadêmica e pessoal com as tecnologias pela qual irei avaliar.',
+				required: true,
+				type: 'termsOfUseReviewers',
+				version: '1',
+			},
+			{
+				description:
+					'Declaro que irei atender aos princípios éticos no uso da Plataforma Sabiá e desempenharei as minhas funções com probidade, boa-fé e de acordo com a legislação vigente, sendo inteiramente responsável pelas condutas lesivas a direitos de terceiros, ao próprio serviço disponibilizado pela plataforma e à Administração Pública, com responsabilização civil contratual e/ou extracontratual e adoção das medidas penais aplicáveis ao caso, conforme os Termos e Condições de Uso.',
+				required: true,
+				type: 'termsOfUseReviewers',
+				version: '1',
+			},
 		]);
 
 		const users = await User.query()
@@ -101,6 +123,7 @@ class DisclaimerSeeder {
 			users.rows.map((user) => {
 				user.acceptMandatory('termsOfUseRegister');
 				user.acceptMandatory('termsOfUseTechnology');
+				user.acceptMandatory('termsOfUseReviewers');
 				return user;
 			}),
 		);

--- a/packages/api/start/routes/auth.js
+++ b/packages/api/start/routes/auth.js
@@ -79,7 +79,7 @@ const Route = use('Route');
  */
 Route.post('/auth/register', 'AuthController.register')
 	.validator('User')
-	.middleware(['disclaimerMiddleware:termsOfUseRegister']);
+	.middleware(['disclaimerMiddleware:register']);
 
 /**
  * @api {post} /auth/login Authenticates a user

--- a/packages/api/start/routes/disclaimers.js
+++ b/packages/api/start/routes/disclaimers.js
@@ -18,7 +18,7 @@ const Route = use('Route');
  * @apiSuccess {Date} updated_at Disclaimer Update date
  * @apiSuccess {String} description Disclaimer Description
  * @apiSuccess {Boolean} required Disclaimer Is required
- * @apiSuccess {String="privacypolicy", "termsOfUseRegister", "termsOfUseTechnology"} type Disclaimer Type
+ * @apiSuccess {String="privacypolicy", "register", "technology", "reviewers"} type Disclaimer Type
  * @apiSuccess {String} version Disclaimer Version
  * @apiSuccessExample {json} Success
  * HTTP/1.1 200 OK
@@ -55,7 +55,7 @@ Route.get('disclaimers/:id', 'DisclaimerController.show').middleware(['handlePar
  * @apiSuccess {Date} updated_at Disclaimer Update date
  * @apiSuccess {String} description Disclaimer Description
  * @apiSuccess {Boolean} required Disclaimer Is required
- * @apiSuccess {String="privacypolicy", "termsOfUseRegister", "termsOfUseTechnology"} type Disclaimer Type
+ * @apiSuccess {String="privacypolicy", "register", "technology", "reviewers"} type Disclaimer Type
  * @apiSuccess {String} version Disclaimer Version
  * @apiSuccessExample {json} Success
  * HTTP/1.1 200 OK
@@ -75,7 +75,7 @@ Route.get('disclaimers/:id', 'DisclaimerController.show').middleware(['handlePar
  *        "updated_at": "2020-10-28 13:29:44",
  *        "description": "Concordo com o processamento dos meus dados pessoais para fins de fornecimento dos serviços da Plataforma Sabiá. Veja mais na Política de Privacidade. ",
  *        "required": 1,
- *        "type": "termsOfUseRegister",
+ *        "type": "register",
  *        "version": "1"
  *    }
  *]
@@ -95,13 +95,13 @@ Route.get('disclaimers', 'DisclaimerController.index').middleware(['handleParams
  *    }
  * @apiParam {String} description Disclaimer Description
  * @apiParam {Boolean} required Disclaimer Is required
- * @apiParam {String="privacypolicy", "termsOfUseRegister", "termsOfUseTechnology"} type Disclaimer Type
+ * @apiParam {String="privacypolicy", "register", "technology", "reviewers"} type Disclaimer Type
  * @apiParam {String} version Disclaimer Version
  * @apiParamExample  {json} Request sample:
  * {
  *   "description": "Declaro ciência dos Termos e Condições de Uso.",
  *	 "required": true,
- *	 "type": "termsOfUseRegister",
+ *	 "type": "register",
  *	 "version": "1"
  *  }
  * @apiSuccess {Number} id Disclaimer ID
@@ -119,7 +119,7 @@ Route.get('disclaimers', 'DisclaimerController.index').middleware(['handleParams
  * 	"updated_at": "2020-10-21 11:42:14",
  * 	"description": "Declaro ciência dos Termos e Condições de Uso.",
  * 	"required": true,
- * 	"type": "termsOfUseRegister",
+ * 	"type": "register",
  * 	"version": "1"
  *  }
  *@apiError (Bad Request 400) {Object} error Error object
@@ -132,7 +132,7 @@ Route.get('disclaimers', 'DisclaimerController.index').middleware(['handleParams
  *   			"error_code": "VALIDATION_ERROR",
  *   			"message": [
  *     				{
- *       				"message": "type deve estar entre os valores (privacypolicy,termsOfUseRegister,termsOfUseTechnology).",
+ *       				"message": "type deve estar entre os valores (privacypolicy,register,technology).",
  *       				"field": "type",
  *       				"validation": "in"
  *     				}
@@ -168,7 +168,7 @@ Route.post('disclaimers', 'DisclaimerController.store')
  *    }
  * @apiParam {String} description Disclaimer Description
  * @apiParam {Boolean} required Disclaimer Is required
- * @apiParam {String="privacypolicy", "termsOfUseRegister", "termsOfUseTechnology"} type Disclaimer Type
+ * @apiParam {String="privacypolicy", "register", "technology", "reviewers"} type Disclaimer Type
  * @apiParam {String} version Disclaimer Version
  * @apiParamExample  {json} Request sample:
  *    {
@@ -189,7 +189,7 @@ Route.post('disclaimers', 'DisclaimerController.store')
  * 	"updated_at": "2020-10-21 11:42:14",
  * 	"description": "Updated User Disclaimer Description",
  * 	"required": true,
- * 	"type": "termsOfUseRegister",
+ * 	"type": "register",
  * 	"version": "1"
  *  }
  *@apiError (Forbidden 403) {Object} error Error object
@@ -327,7 +327,7 @@ Route.delete('disclaimers/', 'DisclaimerController.destroyMany').middleware([
  * @apiSuccess {Date} updated_at Disclaimer Update date
  * @apiSuccess {String} description Disclaimer Description
  * @apiSuccess {Boolean} required Disclaimer Is required
- * @apiSuccess {String="privacypolicy", "termsOfUseRegister", "termsOfUseTechnology"} type Disclaimer Type
+ * @apiSuccess {String="privacypolicy", "register", "technology", "reviewers"} type Disclaimer Type
  * @apiSuccess {String} version Disclaimer Version
  * @apiSuccess {Number} pivot.disclaimer_id Disclaimer ID
  * @apiSuccess {Number} pivot.user_id User ID
@@ -340,7 +340,7 @@ Route.delete('disclaimers/', 'DisclaimerController.destroyMany').middleware([
  *        "updated_at": "2020-10-28 13:29:44",
  *        "description": "Estou ciente de que posso revogar o consentimento de uso dos meus dados pessoais a qualquer momento. Todavia, não poderei mais utilizar os serviços da plataforma que necessitam do uso e da coleta de dados pessoais. Veja mais na Política de Privacidade. ",
  *        "required": 1,
- *        "type": "termsOfUseRegister",
+ *        "type": "register",
  *        "version": "1",
  *        "pivot": {
  *            "disclaimer_id": 1,
@@ -353,7 +353,7 @@ Route.delete('disclaimers/', 'DisclaimerController.destroyMany').middleware([
  *        "updated_at": "2020-10-28 13:29:44",
  *        "description": "Estou ciente quanto ao canal de suporte da Plataforma Sabiá, que estará à disposição para sanar eventual dúvida que possa surgir.",
  *        "required": 1,
- *        "type": "termsOfUseRegister",
+ *        "type": "register",
  *        "version": "1",
  *        "pivot": {
  *            "disclaimer_id": 1,

--- a/packages/api/start/routes/reviewers.js
+++ b/packages/api/start/routes/reviewers.js
@@ -294,7 +294,7 @@ Route.get('reviewers/:id', 'ReviewerController.show').middleware([
  *		}
  */
 Route.post('reviewers', 'ReviewerController.store')
-	.middleware(['auth', 'registrationCompleted:be_curator'])
+	.middleware(['auth', 'registrationCompleted:be_curator', 'disclaimerMiddleware:reviewers'])
 	.validator('StoreReviewer');
 /**
  * @api {put} /reviewers Updates Reviewer Categories

--- a/packages/api/test/functional/disclaimers.spec.js
+++ b/packages/api/test/functional/disclaimers.spec.js
@@ -125,7 +125,7 @@ test('POST /auth/register returns an error when the user does not accept all ter
 	assert,
 }) => {
 	const allDisclaimers = await Disclaimer.query()
-		.where('type', 'termsOfUseRegister')
+		.where('type', 'register')
 		.fetch();
 
 	const disclamers = await allDisclaimers

--- a/packages/web/services/user.js
+++ b/packages/web/services/user.js
@@ -59,7 +59,11 @@ export const requestToBeReviewer = async (id, { categories } = {}) => {
 		return false;
 	}
 
-	const response = await apiPost('reviewers', { user_id: id, categories });
+	const response = await apiPost('reviewers', {
+		user_id: id,
+		categories,
+		disclaimers: Array.from(Array(15).keys()),
+	});
 
 	if (response.status !== 200) return false;
 


### PR DESCRIPTION
## Summary

<!-- Por favor, referencie a issue que esse PR se refere. -->
Resolves #575 

## Relevant technical choices
<!-- Descreva as decisões técnicas relevantes -->
Exige que o usuário aceite os termos de uso mais recentes ao solicitar ser curador.
| --- | Router | Type of Terms of Use |
| --- | --- | --- |
POST | reviewers | reviewers


```
{
     "categories": [cat_id1, cat_id2 ...],
     "disclaimers":[TermsOfUse_id1,TermsOfUse_id2...]
}
```

O erro enviado pelo middleware contém uma lista dos termos de uso pendentes de aceite para aquela rota especifica.

```
{
    "error": {
        "error_code": "TERMSOFUSE",
        "message": "Acceptance of the terms of use is mandatory",
        "payload": [
            {
                "id": 2,
                "created_at": "2020-10-20 13:08:49",
                "updated_at": "2020-10-20 13:08:49",
                "description": "Concordo com o processamento dos meus dados pessoais para fins de fornecimento dos serviços da Plataforma Sabiá. Veja mais na Política de Privacidade. ",
                "required": 1,
                "type": "termsOfUseRegister",
                "version": "1"
            },
            {
                "id": 3,
                "created_at": "2020-10-20 13:08:49",
                "updated_at": "2020-10-20 13:08:49",
                "description": "Concordo em respeitar a legislação brasileira vigente no conteúdo que eu venha a disponibilizar na Plataforma Sabiá, sendo de minha exclusiva responsabilidade. Veja mais nos Termos e Condições de Uso. ",
                "required": 1,
                "type": "termsOfUseRegister",
                "version": "1"
            },
        ]
    }
}
```
## QA Steps

Enviar uma requisição **POST** para a rota` /reviewers`

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
