### PR TITLE
Update react-icons to remove pId warning from tests

### DIFF
--- a/packages/web/components/Card/Share/__tests__/__snapshots__/index.js.snap
+++ b/packages/web/components/Card/Share/__tests__/__snapshots__/index.js.snap
@@ -254,7 +254,6 @@ exports[`ShareModal component should open the sharing modal when clicking 1`] = 
               class=""
               fill="currentColor"
               height="25"
-              size="25"
               stroke="currentColor"
               stroke-width="0"
               viewBox="0 0 1024 1024"
@@ -275,7 +274,6 @@ exports[`ShareModal component should open the sharing modal when clicking 1`] = 
               class=""
               fill="currentColor"
               height="25"
-              size="25"
               stroke="currentColor"
               stroke-width="0"
               viewBox="0 0 1024 1024"
@@ -296,7 +294,6 @@ exports[`ShareModal component should open the sharing modal when clicking 1`] = 
               class=""
               fill="currentColor"
               height="25"
-              size="25"
               stroke="currentColor"
               stroke-width="0"
               viewBox="0 0 1024 1024"
@@ -317,8 +314,6 @@ exports[`ShareModal component should open the sharing modal when clicking 1`] = 
               class=""
               fill="currentColor"
               height="25"
-              pId="14972"
-              size="25"
               stroke="currentColor"
               stroke-width="0"
               t="1569683925316"
@@ -330,11 +325,9 @@ exports[`ShareModal component should open the sharing modal when clicking 1`] = 
               <defs />
               <path
                 d="M713.5 599.9c-10.9-5.6-65.2-32.2-75.3-35.8-10.1-3.8-17.5-5.6-24.8 5.6-7.4 11.1-28.4 35.8-35 43.3-6.4 7.4-12.9 8.3-23.8 2.8-64.8-32.4-107.3-57.8-150-131.1-11.3-19.5 11.3-18.1 32.4-60.2 3.6-7.4 1.8-13.7-1-19.3-2.8-5.6-24.8-59.8-34-81.9-8.9-21.5-18.1-18.5-24.8-18.9-6.4-0.4-13.7-0.4-21.1-0.4-7.4 0-19.3 2.8-29.4 13.7-10.1 11.1-38.6 37.8-38.6 92s39.5 106.7 44.9 114.1c5.6 7.4 77.7 118.6 188.4 166.5 70 30.2 97.4 32.8 132.4 27.6 21.3-3.2 65.2-26.6 74.3-52.5 9.1-25.8 9.1-47.9 6.4-52.5-2.7-4.9-10.1-7.7-21-13z"
-                pId="14973"
               />
               <path
                 d="M925.2 338.4c-22.6-53.7-55-101.9-96.3-143.3-41.3-41.3-89.5-73.8-143.3-96.3C630.6 75.7 572.2 64 512 64h-2c-60.6 0.3-119.3 12.3-174.5 35.9-53.3 22.8-101.1 55.2-142 96.5-40.9 41.3-73 89.3-95.2 142.8-23 55.4-34.6 114.3-34.3 174.9 0.3 69.4 16.9 138.3 48 199.9v152c0 25.4 20.6 46 46 46h152.1c61.6 31.1 130.5 47.7 199.9 48h2.1c59.9 0 118-11.6 172.7-34.3 53.5-22.3 101.6-54.3 142.8-95.2 41.3-40.9 73.8-88.7 96.5-142 23.6-55.2 35.6-113.9 35.9-174.5 0.3-60.9-11.5-120-34.8-175.6z m-151.1 438C704 845.8 611 884 512 884h-1.7c-60.3-0.3-120.2-15.3-173.1-43.5l-8.4-4.5H188V695.2l-4.5-8.4C155.3 633.9 140.3 574 140 513.7c-0.4-99.7 37.7-193.3 107.6-263.8 69.8-70.5 163.1-109.5 262.8-109.9h1.7c50 0 98.5 9.7 144.2 28.9 44.6 18.7 84.6 45.6 119 80 34.3 34.3 61.3 74.4 80 119 19.4 46.2 29.1 95.2 28.9 145.8-0.6 99.6-39.7 192.9-110.1 262.7z"
-                pId="14974"
               />
             </svg>
           </button>
@@ -347,7 +340,6 @@ exports[`ShareModal component should open the sharing modal when clicking 1`] = 
               class=""
               fill="currentColor"
               height="25"
-              size="25"
               stroke="currentColor"
               stroke-width="0"
               viewBox="0 0 1024 1024"

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -15668,15 +15668,11 @@
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
       "dev": true,
-      "requires": {
-        "icu4c-data": "^0.67.2"
-      },
       "dependencies": {
         "icu4c-data": {
           "version": "0.67.2",
           "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
-          "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
-          "dev": true
+          "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g=="
         }
       }
     },
@@ -27390,12 +27386,9 @@
       }
     },
     "react-icons": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.10.0.tgz",
-      "integrity": "sha512-WsQ5n1JToG9VixWilSo1bHv842Cj5aZqTGiS3Ud47myF6aK7S/IUY2+dHcBdmkQcCFRuHsJ9OMUI0kTDfjyZXQ==",
-      "requires": {
-        "camelcase": "^5.0.0"
-      }
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.1.0.tgz",
+      "integrity": "sha512-FCXBg1JbbR0vWALXIxmFAfozHdVIJmmwCD81Jk0EKOt7Ax4AdBNcaRkWhR0NaKy9ugJgoY3fFvo0PHpte55pXg=="
     },
     "react-input-autosize": {
       "version": "2.2.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -39,7 +39,7 @@
     "react-dropzone": "^11.0.2",
     "react-hook-form": "^5.6.3",
     "react-i18next": "^11.4.0",
-    "react-icons": "^3.9.0",
+    "react-icons": "^4.1.0",
     "react-input-mask": "^2.0.4",
     "react-instantsearch-dom": "^6.4.0",
     "react-keyed-flatten-children": "^1.2.0",


### PR DESCRIPTION
## Summary

No more warnings in web tests 🎉 

![image](https://user-images.githubusercontent.com/13091635/100351923-fd082200-2fca-11eb-8289-b7df6863a43a.png)

## QA Steps

* Run `npm install`
* Run web tests
