### PR TITLE
Only index to algolia when technology status is published

### DIFF
--- a/packages/api/app/Controllers/Http/TechnologyCostController.js
+++ b/packages/api/app/Controllers/Http/TechnologyCostController.js
@@ -2,7 +2,7 @@ const Technology = use('App/Models/Technology');
 const TechnologyCost = use('App/Models/TechnologyCost');
 const Cost = use('App/Models/Cost');
 
-const { getTransaction, indexToAlgolia } = require('../../Utils');
+const { getTransaction, indexToAlgolia, technologyStatuses } = require('../../Utils');
 
 const getFields = (request) =>
 	request.only([
@@ -72,6 +72,7 @@ class TechnologyCostController {
 	async update({ request, params }) {
 		const { costs, ...data } = getFields(request);
 		const technology = await Technology.findOrFail(params.id);
+		const { status } = technology;
 		let trx;
 		let technologyCost;
 		try {
@@ -100,7 +101,9 @@ class TechnologyCostController {
 			throw error;
 		}
 
-		indexToAlgolia(technology);
+		if (status === technologyStatuses.PUBLISHED) {
+			indexToAlgolia(technology);
+		}
 
 		return technologyCost;
 	}


### PR DESCRIPTION
## Summary

<!-- Por favor, referencie a issue que esse PR se refere. -->

Remove algolia indexing when updating the cost of a technology and it is not published

Resolves #675

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [ ] My code has proper inline documentation.
- [ ] I have manually tested this PR.
