### PR TITLE
Hotfix/api/technology questions

### DIFF
--- a/packages/api/app/Controllers/Http/TechnologyController.js
+++ b/packages/api/app/Controllers/Http/TechnologyController.js
@@ -572,7 +572,7 @@ class TechnologyController {
 	async showQuestions({ params, request }) {
 		return TechnologyQuestion.query()
 			.where({ technology_id: params.id })
-			.whereNot({ status: questionStatuses.DISABLED })
+			.where({ status: questionStatuses.ANSWERED })
 			.withParams(request, { filterById: false });
 	}
 }

--- a/packages/api/start/routes/technologyQuestions.js
+++ b/packages/api/start/routes/technologyQuestions.js
@@ -43,6 +43,28 @@ const Route = use('Route');
  */
 Route.get('questions', 'TechnologyQuestionController.index').middleware(['auth', 'handleParams']);
 /**
+ * @api {get} /questions/unanswered Gets the count of unanswered questions of the logged in user
+ * @apiGroup Technology Questions
+ * @apiHeader {String} Authorization Authorization Bearer Token.
+ * @apiHeaderExample {json} Header-Example:
+ *    {
+ *      "Authorization": "Bearer <token>"
+ *    }
+ * @apiParamExample  {json} Request sample:
+ *	/questions/unanswered
+ * @apiSuccess {Number} total_unanswered number of unanswered questions
+ * @apiSuccessExample {json} Success
+ * HTTP/1.1 200 OK
+ * {
+ *  "total_unanswered": 3
+ * }
+ * @apiUse AuthError
+ */
+Route.get(
+	'questions/unanswered',
+	'TechnologyQuestionController.getCountUnansweredQuestions',
+).middleware(['auth']);
+/**
  * @api {get} /questions/:id Shows a public question
  * @apiGroup Technology Questions
  * @apiParamExample  {json} Request sample:

--- a/packages/api/test/functional/technology-question.spec.js
+++ b/packages/api/test/functional/technology-question.spec.js
@@ -74,7 +74,7 @@ test('GET /technologies/:id/questions returns technology questions', async ({ cl
 	const response = await client.get(`/technologies/${technology.id}/questions`).end();
 	const questions = await TechnologyQuestion.query()
 		.where({ technology_id: technology.id })
-		.whereNot({ status: questionStatuses.DISABLED })
+		.where({ status: questionStatuses.ANSWERED })
 		.limit(10)
 		.fetch();
 

--- a/packages/api/test/functional/technology-question.spec.js
+++ b/packages/api/test/functional/technology-question.spec.js
@@ -32,6 +32,43 @@ test('GET /questions returns the questions of the logged in user', async ({ clie
 	response.assertJSONSubset({ ...questions.rows });
 });
 
+test('GET /questions/unanswered returns the quantity of questions unanswered of the logged in user', async ({
+	client,
+}) => {
+	const { user: owner } = await createUser();
+	const { user: asker } = await createUser();
+	const technology = await Factory.model('App/Models/Technology').create();
+	await technology.users().attach(owner.id);
+	const answeredQuestions = await Factory.model('App/Models/TechnologyQuestion').createMany(5);
+	const unansweredQuetions = await Factory.model('App/Models/TechnologyQuestion').createMany(5);
+
+	await Promise.all(
+		answeredQuestions.map(async (question) => {
+			await question.technology().associate(technology);
+			await question.user().associate(asker);
+			question.status = questionStatuses.ANSWERED;
+			await question.save();
+		}),
+	);
+
+	await Promise.all(
+		unansweredQuetions.map(async (question) => {
+			await question.technology().associate(technology);
+			await question.user().associate(asker);
+			question.status = questionStatuses.UNANSWERED;
+			await question.save();
+		}),
+	);
+
+	const response = await client
+		.get(`/questions/unanswered`)
+		.loginVia(owner, 'jwt')
+		.end();
+
+	response.assertStatus(200);
+	response.assertJSONSubset({ total_unanswered: unansweredQuetions.length });
+});
+
 test('GET /questions returns all questions if user is an admin', async ({ client }) => {
 	const { user: admin } = await createUser({
 		append: { role: roles.REVIEWER },


### PR DESCRIPTION
## Summary

Resolves #693

## Relevant technical choices

1. A rota que lista perguntas públicas da tecnologia retorna apenas perguntas que estejam respondidas;
2. Nova rota (retorna a quantidade de perguntas não respondidas do usuário logado)

```javascript
GET /questions/unanswered
{
  "total_unanswered": 3
}
```

## QA Steps

Rodar teste: `adonis test --files test/functional/technology-question.spec.js   `


## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
