### PR TITLE
Lists user orders in user show route with embed

### DIFF
--- a/packages/api/app/Models/Traits/Params.js
+++ b/packages/api/app/Models/Traits/Params.js
@@ -24,6 +24,7 @@ class Params {
 				'institution',
 				'messages',
 				'ideas',
+				'orders',
 			],
 			taxonomies: ['terms'],
 			terms: ['taxonomy', 'technologies', 'metas', 'reviewers'],

--- a/packages/api/app/Models/User.js
+++ b/packages/api/app/Models/User.js
@@ -205,6 +205,10 @@ class User extends Model {
 		return this.hasMany('App/Models/Idea');
 	}
 
+	orders() {
+		return this.hasMany('App/Models/TechnologyOrder');
+	}
+
 	generateToken(type) {
 		return this.tokens().create({
 			type,


### PR DESCRIPTION
## Summary

Resolves #722

## Relevant technical choices

Para listar as orders do user basta fazer `GET /users/:id?embed`, no response body:

```json
"orders": [
    {
      "id": 6,
      "user_id": 13,
      "technology_id": 11,
      "quantity": 1,
      "status": "open",
      "use": "private",
      "funding": "no_need_funding",
      "comment": "test",
      "cancellation_reason": null,
      "unit_value": null,
      "created_at": "2020-12-21 19:56:05",
      "updated_at": "2020-12-21 19:56:05"
    },
    {
      "id": 7,
      "user_id": 13,
      "technology_id": 1,
      "quantity": 1,
      "status": "open",
      "use": "private",
      "funding": "no_need_funding",
      "comment": "test",
      "cancellation_reason": null,
      "unit_value": null,
      "created_at": "2020-12-21 19:57:31",
      "updated_at": "2020-12-21 19:57:31"
    }
  ]
```

## QA Steps

1. Criar uma order com um usuário x;
2. Fazer uma requisição para `GET /users/x?embed`
3. Ver o campo `orders` no response body

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
