### PR TITLE
Fix e2e update user test

### DIFF
--- a/cypress/e2e/web/updateUser.js
+++ b/cypress/e2e/web/updateUser.js
@@ -23,7 +23,9 @@ describe('User form validation', () => {
 					.type(userData.full_name);
 			});
 
-			cy.get('input[name=cpf]').type('44455');
+			cy.get('input[name=cpf]')
+				.clear()
+				.type('44455');
 
 			cy.findByText(/^(salvar alterações|save changes)$/i).click();
 			cy.findAllByText(

--- a/packages/web/pages/user/my-account/index.js
+++ b/packages/web/pages/user/my-account/index.js
@@ -169,7 +169,9 @@ const CommonDataForm = ({ form, user, message, loading }) => {
 						form={form}
 						name="cpf"
 						label={t('account:labels.cpf')}
-						defaultValue={user?.cpf ?? ''}
+						defaultValue={
+							user?.cpf?.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4') ?? ''
+						}
 						placeholder={t('account:placeholders.cpf')}
 						mask="999.999.999-99"
 						pattern={/^\d{3}\.\d{3}\.\d{3}-\d{2}$/}
@@ -210,7 +212,7 @@ const CommonDataForm = ({ form, user, message, loading }) => {
 						form={form}
 						name="zipcode"
 						label={t('account:labels.zipCode')}
-						defaultValue={user?.zipcode ?? ''}
+						defaultValue={user?.zipcode.replace(/(\d{5})(\d{3})/, '$1-$2') ?? ''}
 						placeholder={t('account:placeholders.zipCode')}
 						mask="99999-999"
 						pattern={/^\d{5}-\d{3}$/}


### PR DESCRIPTION
## Summary

This PR fixes e2e test (updateUser) and format CPF and Zipcode fields before passing into react-masked-input

![image](https://user-images.githubusercontent.com/13091635/106402979-0e2a4080-640b-11eb-979f-1468a4061a42.png)

## QA Steps

1 .Run e2e test
2. Try to update user just by hitting save button

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
