### PR TITLE
Adjust cypress test when typing in CKEditor

### DIFF
--- a/cypress/e2e/web/createTechnology.js
+++ b/cypress/e2e/web/createTechnology.js
@@ -168,7 +168,9 @@ describe('creating/editing technology', () => {
 			cy.findByText(/salvar e continuar/i, { selector: 'button' }).should('not.exist');
 			cy.findByText(/voltar/i, { selector: 'button' }).should('exist');
 
-			cy.get('textarea[name=comment]').type('To uhibewcuv le roos leotine.');
+			cy.get('div[role="textbox"][contenteditable="true"]').type(
+				'To uhibewcuv le roos leotine.',
+			);
 
 			cy.get('label[for=acceptTrueInformationTerms]').click();
 			cy.get('label[for=acceptResponsibilityTerms]').click();


### PR DESCRIPTION
## Summary

Just fix how we're getting researcher comment field, so Cypress doesn't breaks.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
