### PR TITLE
Improve/api/seed default

### DIFF
--- a/packages/api/app/Models/Permission.js
+++ b/packages/api/app/Models/Permission.js
@@ -15,12 +15,44 @@ const ServiceOrder = use('App/Models/ServiceOrder');
 const ServiceOrderReview = use('App/Models/ServiceOrderReview');
 
 const CE = require('@adonisjs/lucid/src/Exceptions');
+const GE = require('@adonisjs/generic-exceptions');
 const { permissions, matchesPermission } = require('../Utils');
 
 class Permission extends Model {
 	static boot() {
 		super.boot();
 		this.addTrait('Params');
+	}
+
+	static async create(payload) {
+		let modelInstance;
+		const permission = await this.findBy('permission', payload.permission);
+		if (!permission) {
+			modelInstance = new Permission();
+			modelInstance.fill(payload);
+			await modelInstance.save();
+		}
+
+		return modelInstance;
+	}
+
+	static async createMany(payloadArray) {
+		if (!Array.isArray(payloadArray)) {
+			throw GE.InvalidArgumentException.invalidParameter(
+				`${this.name}.createMany expects an array of values`,
+				payloadArray,
+			);
+		}
+
+		const rows = [];
+		for (const payload of payloadArray) {
+			// eslint-disable-next-line no-await-in-loop
+			const row = await this.create(payload);
+			if (row) {
+				rows.push(row);
+			}
+		}
+		return rows;
 	}
 
 	roles() {

--- a/packages/api/app/Models/Role.js
+++ b/packages/api/app/Models/Role.js
@@ -1,5 +1,6 @@
 /* @type {typeof import('@adonisjs/lucid/src/Lucid/Model')} */
 const Model = use('Model');
+const GE = require('@adonisjs/generic-exceptions');
 
 class Role extends Model {
 	static boot() {
@@ -13,6 +14,39 @@ class Role extends Model {
 
 	permissions() {
 		return this.belongsToMany('App/Models/Permission');
+	}
+
+	static async create(payload) {
+		let modelInstance;
+		const role = await this.findBy('role', payload.role);
+		if (!role) {
+			modelInstance = new Role();
+			modelInstance.fill(payload);
+			await modelInstance.save();
+		}
+
+		return modelInstance;
+	}
+
+	static async createMany(payloadArray) {
+		if (!Array.isArray(payloadArray)) {
+			throw GE.InvalidArgumentException.invalidParameter(
+				`${this.name}.createMany expects an array of values`,
+				payloadArray,
+			);
+		}
+
+		const rows = [];
+		await Promise.all(
+			payloadArray.map(async (payload) => {
+				const row = await this.create(payload);
+				if (row) {
+					rows.push(row);
+				}
+			}),
+		);
+
+		return rows;
 	}
 
 	static async getRole(role) {

--- a/packages/api/app/Models/Role.js
+++ b/packages/api/app/Models/Role.js
@@ -37,15 +37,13 @@ class Role extends Model {
 		}
 
 		const rows = [];
-		await Promise.all(
-			payloadArray.map(async (payload) => {
-				const row = await this.create(payload);
-				if (row) {
-					rows.push(row);
-				}
-			}),
-		);
-
+		for (const payload of payloadArray) {
+			// eslint-disable-next-line no-await-in-loop
+			const row = await this.create(payload);
+			if (row) {
+				rows.push(row);
+			}
+		}
 		return rows;
 	}
 

--- a/packages/api/app/Models/Taxonomy.js
+++ b/packages/api/app/Models/Taxonomy.js
@@ -2,11 +2,43 @@
 const Model = use('Model');
 const Term = use('App/Models/Term');
 const CE = require('@adonisjs/lucid/src/Exceptions');
+const GE = require('@adonisjs/generic-exceptions');
 
 class Taxonomy extends Model {
 	static boot() {
 		super.boot();
 		this.addTrait('Params');
+	}
+
+	static async create(payload) {
+		let modelInstance;
+		const taxonomy = await this.findBy('taxonomy', payload.taxonomy);
+		if (!taxonomy) {
+			modelInstance = new Taxonomy();
+			modelInstance.fill(payload);
+			await modelInstance.save();
+		}
+
+		return modelInstance;
+	}
+
+	static async createMany(payloadArray) {
+		if (!Array.isArray(payloadArray)) {
+			throw GE.InvalidArgumentException.invalidParameter(
+				`${this.name}.createMany expects an array of values`,
+				payloadArray,
+			);
+		}
+
+		const rows = [];
+		for (const payload of payloadArray) {
+			// eslint-disable-next-line no-await-in-loop
+			const row = await this.create(payload);
+			if (row) {
+				rows.push(row);
+			}
+		}
+		return rows;
 	}
 
 	terms() {

--- a/packages/api/database/seeds/00_RoleSeeder.js
+++ b/packages/api/database/seeds/00_RoleSeeder.js
@@ -34,6 +34,14 @@ class RoleSeeder {
 				role: roles.ADMIN,
 				description: 'Usuário Administrador',
 			},
+			{
+				role: 'TEST_ROLE',
+				description: 'Test user',
+			},
+			{
+				role: 'TEST_ROLE_3',
+				description: 'Test user 3',
+			},
 		]);
 	}
 }

--- a/packages/api/database/seeds/00_RoleSeeder.js
+++ b/packages/api/database/seeds/00_RoleSeeder.js
@@ -34,14 +34,6 @@ class RoleSeeder {
 				role: roles.ADMIN,
 				description: 'Usuário Administrador',
 			},
-			{
-				role: 'TEST_ROLE',
-				description: 'Test user',
-			},
-			{
-				role: 'TEST_ROLE_3',
-				description: 'Test user 3',
-			},
 		]);
 	}
 }

--- a/packages/api/database/seeds/01_KnowledgeAreaSeeder.js
+++ b/packages/api/database/seeds/01_KnowledgeAreaSeeder.js
@@ -17,38 +17,42 @@ class KnowledgeAreaSeeder {
 		const rawdata = await fs.readFile(Helpers.resourcesPath('json/knowledge_areas.json'));
 		const areasJson = JSON.parse(rawdata);
 
-		try {
-			const areas = areasJson.map((area) => {
-				let name;
-				switch (area.NUMERO_NIVEL) {
-					case 1:
-						name = area.NOME_GRANDE_AREA;
-						break;
-					case 2:
-						name = area.NOME_AREA;
-						break;
-					case 3:
-						name = area.NOME_SUB_AREA;
-						break;
-					case 4:
-						name = area.NOME_ESPECIALIDADE;
-						break;
-					default:
-						throw new Error('Undefined Level');
-				}
-				return {
-					knowledge_area_id: area.CODIGO_AREA_CONHECIMENTO,
-					level: area.NUMERO_NIVEL,
-					name,
-					great_area_id: area.CODIGO_GRANDE_AREA ? area.CODIGO_GRANDE_AREA : null,
-					area_id: area.CODIGO_AREA ? area.CODIGO_AREA : null,
-					sub_area_id: area.CODIGO_SUB_AREA ? area.CODIGO_SUB_AREA : null,
-					speciality_id: area.CODIGO_ESPECIALIDADE ? area.CODIGO_ESPECIALIDADE : null,
-				};
-			});
-			await Database.table('knowledge_areas').insert(areas);
-		} catch (error) {
-			throw new Error(error);
+		const countAreas = await Database.table('knowledge_areas').getCount();
+
+		if (countAreas === 0) {
+			try {
+				const areas = areasJson.map((area) => {
+					let name;
+					switch (area.NUMERO_NIVEL) {
+						case 1:
+							name = area.NOME_GRANDE_AREA;
+							break;
+						case 2:
+							name = area.NOME_AREA;
+							break;
+						case 3:
+							name = area.NOME_SUB_AREA;
+							break;
+						case 4:
+							name = area.NOME_ESPECIALIDADE;
+							break;
+						default:
+							throw new Error('Undefined Level');
+					}
+					return {
+						knowledge_area_id: area.CODIGO_AREA_CONHECIMENTO,
+						level: area.NUMERO_NIVEL,
+						name,
+						great_area_id: area.CODIGO_GRANDE_AREA ? area.CODIGO_GRANDE_AREA : null,
+						area_id: area.CODIGO_AREA ? area.CODIGO_AREA : null,
+						sub_area_id: area.CODIGO_SUB_AREA ? area.CODIGO_SUB_AREA : null,
+						speciality_id: area.CODIGO_ESPECIALIDADE ? area.CODIGO_ESPECIALIDADE : null,
+					};
+				});
+				await Database.table('knowledge_areas').insert(areas);
+			} catch (error) {
+				throw new Error(error);
+			}
 		}
 	}
 }

--- a/packages/api/database/seeds/03_TermSeeder.js
+++ b/packages/api/database/seeds/03_TermSeeder.js
@@ -22,13 +22,11 @@ class TermSeeder {
 		 */
 		const classificationTaxonomy = await Taxonomy.getTaxonomy('CLASSIFICATION');
 
-		await classificationTaxonomy
-			.terms()
-			.createMany([
-				{ term: 'Avanços tecnológicos' },
-				{ term: 'Tecnologias Sociais' },
-				{ term: 'Inovações sociais' },
-			]);
+		await classificationTaxonomy.terms().createMany([
+			{ term: 'Avanços tecnológicos', slug: 'avancos-tecnologicos' },
+			{ term: 'Tecnologias Sociais', slug: 'tecnologias-sociais' },
+			{ term: 'Inovações sociais', slug: 'inovacoes-sociais' },
+		]);
 
 		/**
 		 * STAGE
@@ -40,38 +38,14 @@ class TermSeeder {
 
 		await stageTaxonomy.terms().createMany([
 			{ term: 'Nível 1 - Princípios básicos observados e relatados', slug: 'stage-1' },
-			{ term: 'Nível 2 - Conceito e/ou aplicação da tecnologia formulados', slug: 'stage-2' },
-			{
-				term:
-					'Nível 3 - Prova de conceito analítica e experimental de características e/ou funções críticas',
-				slug: 'stage-3',
-			},
-			{
-				term:
-					'Nível 4 - Verificação funcional de componente e/ou subsistema em ambiente laboratorial',
-				slug: 'stage-4',
-			},
-			{
-				term:
-					'Nível 5 - Verificação da função crítica do componente e/ou subsistema em ambiente relevante',
-				slug: 'stage-5',
-			},
-			{
-				term:
-					'Nível 6 - Demonstração do modelo de protótipo de sistema/subsistema em ambiente relevante',
-				slug: 'stage-6',
-			},
-			{
-				term:
-					'Nível 7 - Demonstração do protótipo de sistema/subsistema em ambiente operacional',
-				slug: 'stage-7',
-			},
-			{ term: 'Nível 8 - Sistema real desenvolvido e aprovado', slug: 'stage-8' },
-			{
-				term:
-					'Nível 9 - Sistema real desenvolvido e aprovado através de operações bem-sucedidas',
-				slug: 'stage-9',
-			},
+			{ term: 'Nível 2 - Conceito ou aplicação da tecnologia formulados', slug: 'stage-2' },
+			{ term: 'Nível 3 - Prova de Conceito (PoC)', slug: 'stage-3' },
+			{ term: 'Nível 4 - Testado em Laboratório', slug: 'stage-4' },
+			{ term: 'Nível 5 - Protótipo validado', slug: 'stage-5' },
+			{ term: 'Nível 6 - Testado em campo', slug: 'stage-6' },
+			{ term: 'Nível 7 - Testado em escala', slug: 'stage-7' },
+			{ term: 'Nível 8 - Produto testado e qualificado', slug: 'stage-8' },
+			{ term: 'Nível 9 - Sistema real desenvolvido e aprovado', slug: 'stage-9' },
 		]);
 
 		/**
@@ -84,21 +58,21 @@ class TermSeeder {
 		 */
 		const dimensionTaxonomy = await Taxonomy.getTaxonomy('DIMENSION');
 
-		await dimensionTaxonomy
-			.terms()
-			.createMany([
-				{ term: 'Ambiental' },
-				{ term: 'Social' },
-				{ term: 'Econômica' },
-				{ term: 'Cultural' },
-				{ term: 'Política' },
-			]);
+		await dimensionTaxonomy.terms().createMany([
+			{ term: 'Ambiental', slug: 'ambiental' },
+			{ term: 'Social', slug: 'social' },
+			{ term: 'Econômica', slug: 'economica' },
+			{ term: 'Cultural', slug: 'cultural' },
+			{ term: 'Política', slug: 'politica' },
+			{ term: 'Sócio-ambiental', slug: 'socio-ambiental' },
+			{ term: 'Educacional', slug: 'educacional' },
+		]);
 
 		/**
 		 * CATEGORY AND SUBCATEGORIES
 		    SubCategories are a Category Term with parent_id
 		 */
-		const categoryTaxonomy = await Taxonomy.getTaxonomy('CATEGORY');
+		// const categoryTaxonomy = await Taxonomy.getTaxonomy('CATEGORY');
 
 		/**
 		 * a) Recursos Hídricos;
@@ -109,7 +83,7 @@ class TermSeeder {
 		 * V. Qualidade da Água/ Dessalinização.
 		 * VII. Outros
 		 * */
-		const srhTerm = await categoryTaxonomy.terms().create({ term: 'Recursos Hídricos' });
+		/* const srhTerm = await categoryTaxonomy.terms().create({ term: 'Recursos Hídricos' });
 
 		await categoryTaxonomy.terms().createMany([
 			{
@@ -136,7 +110,7 @@ class TermSeeder {
 				term: 'Outros.',
 				parent_id: srhTerm.id,
 			},
-		]);
+		]); */
 
 		/**
 		 * b) Agricultura de Sequeiro;
@@ -145,7 +119,7 @@ class TermSeeder {
 		 * III. Técnicas para melhorar o meio ambiente e recursos naturais
 		 * IV. Sistemas de produção de sequeiro
 		 * */
-		const sasTerm = await categoryTaxonomy.terms().create({ term: 'Agricultura de Sequeiro' });
+		/* const sasTerm = await categoryTaxonomy.terms().create({ term: 'Agricultura de Sequeiro' });
 
 		await categoryTaxonomy.terms().createMany([
 			{
@@ -164,7 +138,7 @@ class TermSeeder {
 				term: 'Sistemas de produção de sequeiro',
 				parent_id: sasTerm.id,
 			},
-		]);
+		]); */
 
 		/**
 		 * c) Agricultura Irrigada;
@@ -173,7 +147,7 @@ class TermSeeder {
 		 * III. Como evitar salinização
 		 * IV. Outros
 		 * */
-		const saiTerm = await categoryTaxonomy.terms().create({ term: 'Agricultura Irrigada' });
+		/* const saiTerm = await categoryTaxonomy.terms().create({ term: 'Agricultura Irrigada' });
 
 		await categoryTaxonomy.terms().createMany([
 			{
@@ -192,7 +166,7 @@ class TermSeeder {
 				term: 'Outros',
 				parent_id: saiTerm.id,
 			},
-		]);
+		]); */
 
 		/**
 		 * d) Pecuária;
@@ -200,7 +174,7 @@ class TermSeeder {
 		 * II. Produção de forragem
 		 * III. Pecuária e meio ambiente
 		 * */
-		const sepTerm = await categoryTaxonomy.terms().create({ term: 'Pecuária' });
+		/* const sepTerm = await categoryTaxonomy.terms().create({ term: 'Pecuária' });
 
 		await categoryTaxonomy.terms().createMany([
 			{
@@ -215,7 +189,7 @@ class TermSeeder {
 				term: 'Pecuária e meio ambiente',
 				parent_id: sepTerm.id,
 			},
-		]);
+		]); */
 
 		/**
 		 * e) Aquicultura;
@@ -223,7 +197,7 @@ class TermSeeder {
 		 * II. Criação de camarões
 		 * III. Soluções ambientais para a aquicultura
 		 * */
-		const seaTerm = await categoryTaxonomy.terms().create({ term: 'Aquicultura' });
+		/* const seaTerm = await categoryTaxonomy.terms().create({ term: 'Aquicultura' });
 
 		await categoryTaxonomy.terms().createMany([
 			{
@@ -238,7 +212,7 @@ class TermSeeder {
 				term: 'Soluções ambientais para a aquicultura',
 				parent_id: seaTerm.id,
 			},
-		]);
+		]); */
 
 		/**
 		 * f) Recursos Naturais;
@@ -252,7 +226,7 @@ class TermSeeder {
 		 * IX. Patrimônio genético
 		 * X. Recursos minerais, arqueológicos, paleontológicos, especeológicos
 		 * */
-		const smsTerm = await categoryTaxonomy.terms().create({
+		/* const smsTerm = await categoryTaxonomy.terms().create({
 			term: 'Recursos Naturais',
 		});
 
@@ -293,7 +267,7 @@ class TermSeeder {
 				term: 'Recursos minerais, arqueológicos, paleontológicos, especeológicos',
 				parent_id: smsTerm.id,
 			},
-		]);
+		]); */
 
 		/**
 		 * h) Áreas Degradadas;
@@ -302,7 +276,7 @@ class TermSeeder {
 		 * III. Controle de erosão
 		 * IV. Recuperação de bacias hidrográficas
 		 * */
-		const spdTerm = await categoryTaxonomy.terms().create({
+		/* const spdTerm = await categoryTaxonomy.terms().create({
 			term: 'Áreas Degradadas',
 		});
 
@@ -323,7 +297,7 @@ class TermSeeder {
 				term: 'Recuperação de bacias hidrográficas',
 				parent_id: spdTerm.id,
 			},
-		]);
+		]); */
 
 		/**
 		 * i) Sistemas de Produção;
@@ -331,7 +305,7 @@ class TermSeeder {
 		 * II. Sistemas agro-silvo-pecuários
 		 * III. Aumento do potencial das caatingas
 		 * */
-		const sspTerm = await categoryTaxonomy.terms().create({ term: 'Sistemas de Produção' });
+		/* const sspTerm = await categoryTaxonomy.terms().create({ term: 'Sistemas de Produção' });
 
 		await categoryTaxonomy.terms().createMany([
 			{
@@ -346,7 +320,7 @@ class TermSeeder {
 				term: 'Aumento do potencial das caatingas',
 				parent_id: sspTerm.id,
 			},
-		]);
+		]); */
 
 		/**
 		 * j) Atividades Agrícolas.
@@ -356,7 +330,7 @@ class TermSeeder {
 		 * IV. Artesanato
 		 * V. outros.
 		 * */
-		const saaTerm = await categoryTaxonomy.terms().create({
+		/* const saaTerm = await categoryTaxonomy.terms().create({
 			term: 'Atividades Agrícolas',
 		});
 
@@ -381,7 +355,7 @@ class TermSeeder {
 				term: 'Outros',
 				parent_id: saaTerm.id,
 			},
-		]);
+		]); */
 
 		/**
 		 * k) Saneamento Básico
@@ -391,7 +365,7 @@ class TermSeeder {
 		 * IV. Tratamento de esgotos
 		 * V. Destinação de resíduos sólidos
 		 * */
-		const sabTerm = await categoryTaxonomy.terms().create({
+		/* const sabTerm = await categoryTaxonomy.terms().create({
 			term: 'Saneamento Básico',
 		});
 
@@ -416,7 +390,7 @@ class TermSeeder {
 				term: 'Destinação de resíduos sólidos',
 				parent_id: sabTerm.id,
 			},
-		]);
+		]); */
 
 		/**
 		 * l) Educação
@@ -424,7 +398,7 @@ class TermSeeder {
 		 * II. Educação em tempo integral
 		 * III. Educação e calendário agrícola
 		 * */
-		const eduTerm = await categoryTaxonomy.terms().create({
+		/* const eduTerm = await categoryTaxonomy.terms().create({
 			term: 'Educação',
 		});
 
@@ -441,7 +415,7 @@ class TermSeeder {
 				term: 'Educação e calendário agrícola',
 				parent_id: eduTerm.id,
 			},
-		]);
+		]); */
 
 		/**
 		 * TARGET_AUDIENCE
@@ -452,14 +426,16 @@ class TermSeeder {
 		 */
 		const targetAudienceTaxonomy = await Taxonomy.getTaxonomy('TARGET_AUDIENCE');
 
-		await targetAudienceTaxonomy
-			.terms()
-			.createMany([
-				{ term: 'Agricultores' },
-				{ term: 'Empresários' },
-				{ term: 'Estudantes' },
-				{ term: 'Prefeituras' },
-			]);
+		await targetAudienceTaxonomy.terms().createMany([
+			{ term: 'Agricultores', slug: 'agricultores' },
+			{ term: 'Carcinicultores', slug: 'carcinicultores' },
+			{ term: 'Empresários', slug: 'empresarios' },
+			{ term: 'Estudantes', slug: 'estudantes' },
+			{ term: 'Famílias de baixa renda', slug: 'familias-de-baixa-renda' },
+			{ term: 'Moradores da zona urbana', slug: 'moradores-da-zona-urbana' },
+			{ term: 'Poder público', slug: 'poder-publico' },
+			{ term: 'Todos os públicos', slug: 'todos-os-publicos' },
+		]);
 
 		/**
 		 * BIOME
@@ -468,7 +444,15 @@ class TermSeeder {
 		 */
 		const biomeTaxonomy = await Taxonomy.getTaxonomy('BIOME');
 
-		await biomeTaxonomy.terms().createMany([{ term: 'Caatinga' }, { term: 'Zona da Mata' }]);
+		await biomeTaxonomy.terms().createMany([
+			{ term: 'Amazônia', slug: 'amazonia' },
+			{ term: 'Caatinga', slug: 'caatinga' },
+			{ term: 'Cerrado', slug: 'serrado' },
+			{ term: 'Mata Atlântica', slug: 'mata-atlantica' },
+			{ term: 'Não se Aplica', slug: 'nao-se-aplica' },
+			{ term: 'Pampa', slug: 'pampa' },
+			{ term: 'Pantanal', slug: 'pantanal' },
+		]);
 
 		/**
 		 * GOVERNMENT_PROGRAM
@@ -477,13 +461,26 @@ class TermSeeder {
 		 */
 		const governmentProgramTaxonomy = await Taxonomy.getTaxonomy('GOVERNMENT_PROGRAM');
 
-		await governmentProgramTaxonomy
-			.terms()
-			.createMany([{ term: 'Bolsa Família' }, { term: 'Mais Nordeste' }]);
+		await governmentProgramTaxonomy.terms().createMany([
+			{ term: 'Bolsa Família', slug: 'bolsa-familia' },
+			{ term: 'Mais Nordeste', slug: 'mais-nordeste' },
+			{ term: 'Minha Casa Minha Vida', slug: 'minha-casa-minha-vida' },
+			{ term: 'Pacto Mais Brasil', slug: 'pacto-mais-brasil' },
+			{ term: 'Plano AgroNordeste', slug: 'plano-agronordeste' },
+			{
+				term: 'Programa 1 Milhão de Cisternas - P1MC',
+				slug: 'programa-1-milhao-de-cisternas-p1mc',
+			},
+			{ term: 'Programa Casa Verde e Amarela', slug: 'programa-casa-verde-e-amarela' },
+			{
+				term: 'Programa Nacional de Habitação Rural',
+				slug: 'programa-nacional-de-habitacao-rural',
+			},
+		]);
 
 		const regionTaxonomy = await Taxonomy.getTaxonomy('REGION');
 
-		await regionTaxonomy.terms().createMany([{ term: 'Semiárido' }]);
+		await regionTaxonomy.terms().createMany([{ term: 'Semiárido', slug: 'semiarido' }]);
 	}
 }
 

--- a/packages/api/database/seeds/05_TechnologySeeder.js
+++ b/packages/api/database/seeds/05_TechnologySeeder.js
@@ -47,7 +47,7 @@ class TechnologySeeder {
 		const classificationTerms = await Taxonomy.getTaxonomyTerms('CLASSIFICATION');
 		const stageTerms = await Taxonomy.getTaxonomyTerms('STAGE');
 		const dimensionTerms = await Taxonomy.getTaxonomyTerms('DIMENSION');
-		const categoryTerms = await Taxonomy.getTaxonomyTerms('CATEGORY');
+		// const categoryTerms = await Taxonomy.getTaxonomyTerms('CATEGORY');
 		const targetAudienceTerms = await Taxonomy.getTaxonomyTerms('TARGET_AUDIENCE');
 		const biomeTerms = await Taxonomy.getTaxonomyTerms('BIOME');
 		const governmentProgramTerms = await Taxonomy.getTaxonomyTerms('GOVERNMENT_PROGRAM');
@@ -71,14 +71,14 @@ class TechnologySeeder {
 				const dimensionTerm = getRandom(dimensionTerms);
 
 				/** Get a CATEGORY randomly from our terms */
-				const categoryTerm = getRandom(categoryTerms);
+				// const categoryTerm = getRandom(categoryTerms);
 
 				/** Get a SUBCATEGORY randomly from our terms */
-				const subCategoryTerms = await Taxonomy.getTaxonomyTerms(
+				/* const subCategoryTerms = await Taxonomy.getTaxonomyTerms(
 					'CATEGORY',
 					categoryTerm.id,
-				);
-				const subCategoryTerm = getRandom(subCategoryTerms);
+				); 
+				const subCategoryTerm = getRandom(subCategoryTerms); */
 
 				/** Get a TARGET_AUDIENCE randomly from our terms * */
 				const targetAudienceTerm = getRandom(targetAudienceTerms);
@@ -94,19 +94,17 @@ class TechnologySeeder {
 				const keywordTerm = keywordTerms.map((keyword) => keyword.id);
 
 				await keywordTaxonomy.terms().saveMany(keywordTerms);
-				await technology
-					.terms()
-					.attach([
-						governmentProgramTerm,
-						biomeTerm,
-						targetAudienceTerm,
-						subCategoryTerm,
-						categoryTerm,
-						dimensionTerm,
-						stageTerm,
-						classificationTerm,
-						...keywordTerm,
-					]);
+				await technology.terms().attach([
+					governmentProgramTerm,
+					biomeTerm,
+					targetAudienceTerm,
+					// subCategoryTerm,
+					// categoryTerm,
+					dimensionTerm,
+					stageTerm,
+					classificationTerm,
+					...keywordTerm,
+				]);
 
 				const knowledgeAreaSorted =
 					knowledgeAreas.rows[Math.floor(Math.random() * knowledgeAreas.rows.length)];

--- a/packages/api/database/seeds/06_PermissionSeeder.js
+++ b/packages/api/database/seeds/06_PermissionSeeder.js
@@ -15,11 +15,6 @@ class PermissionSeeder {
 	async run() {
 		/* Create All Permissions */
 
-		const permissionsCount = await Permission.getCount();
-		if (permissionsCount > 0) {
-			return;
-		}
-
 		/** ROLE MANAGEMENT */
 		const rolesPermissions = await Permission.createMany([
 			permissions.CREATE_ROLES,
@@ -213,7 +208,12 @@ class PermissionSeeder {
 		const adminRole = await Role.getRole(roles.ADMIN);
 		await adminRole
 			.permissions()
-			.attach([serviceOrderPermissions[1].id, ...adminPermissionsIds]);
+			.attach(
+				[
+					serviceOrderPermissions[1] ? serviceOrderPermissions[1].id : null,
+					...adminPermissionsIds,
+				].filter((e) => e != null),
+			);
 
 		/** RESEARCHER ROLE */
 		const researcherPermissions = [
@@ -236,12 +236,14 @@ class PermissionSeeder {
 		const researcherRole = await Role.getRole(roles.RESEARCHER);
 		await researcherRole
 			.permissions()
-			.attach([
-				technologiesPermissions[0].id,
-				technologyReviewsPermissions[0].id,
-				uploadsPermissions[0].id,
-				...researcherPermissions,
-			]);
+			.attach(
+				[
+					technologiesPermissions[0] ? technologiesPermissions[0].id : null,
+					technologyReviewsPermissions[0] ? technologyReviewsPermissions[0].id : null,
+					uploadsPermissions[0] ? uploadsPermissions[0].id : null,
+					...researcherPermissions,
+				].filter((e) => e != null),
+			);
 
 		/** REVIEWER ROLE */
 		const reviewerPermissions = [...technologyRevisionPermissions].map(
@@ -251,24 +253,28 @@ class PermissionSeeder {
 		const reviewerRole = await Role.getRole(roles.REVIEWER);
 		await reviewerRole
 			.permissions()
-			.attach([
-				technologiesPermissions[0].id,
-				technologyReviewsPermissions[0].id,
-				uploadsPermissions[0].id,
-				...researcherPermissions,
-				...reviewerPermissions,
-			]);
+			.attach(
+				[
+					technologiesPermissions[0] ? technologiesPermissions[0].id : null,
+					technologyReviewsPermissions[0] ? technologyReviewsPermissions[0].id : null,
+					uploadsPermissions[0] ? uploadsPermissions[0].id : null,
+					...researcherPermissions,
+					...reviewerPermissions,
+				].filter((e) => e != null),
+			);
 
 		/** DEFAULT_USER ROLE */
 		const defaultUserRole = await Role.getRole(roles.DEFAULT_USER);
 		await defaultUserRole
 			.permissions()
-			.attach([
-				technologiesPermissions[0].id,
-				technologyReviewsPermissions[0].id,
-				uploadsPermissions[0].id,
-				...researcherPermissions,
-			]);
+			.attach(
+				[
+					technologiesPermissions[0] ? technologiesPermissions[0].id : null,
+					technologyReviewsPermissions[0] ? technologyReviewsPermissions[0].id : null,
+					uploadsPermissions[0] ? uploadsPermissions[0].id : null,
+					...researcherPermissions,
+				].filter((e) => e != null),
+			);
 	}
 }
 

--- a/packages/api/database/seeds/06_PermissionSeeder.js
+++ b/packages/api/database/seeds/06_PermissionSeeder.js
@@ -209,10 +209,7 @@ class PermissionSeeder {
 		await adminRole
 			.permissions()
 			.attach(
-				[
-					serviceOrderPermissions[1] ? serviceOrderPermissions[1].id : null,
-					...adminPermissionsIds,
-				].filter((e) => e != null),
+				[serviceOrderPermissions[1]?.id || null, ...adminPermissionsIds].filter(Boolean),
 			);
 
 		/** RESEARCHER ROLE */
@@ -238,11 +235,11 @@ class PermissionSeeder {
 			.permissions()
 			.attach(
 				[
-					technologiesPermissions[0] ? technologiesPermissions[0].id : null,
-					technologyReviewsPermissions[0] ? technologyReviewsPermissions[0].id : null,
-					uploadsPermissions[0] ? uploadsPermissions[0].id : null,
+					technologiesPermissions[0]?.id || null,
+					technologyReviewsPermissions[0]?.id || null,
+					uploadsPermissions[0]?.id || null,
 					...researcherPermissions,
-				].filter((e) => e != null),
+				].filter(Boolean),
 			);
 
 		/** REVIEWER ROLE */
@@ -255,12 +252,12 @@ class PermissionSeeder {
 			.permissions()
 			.attach(
 				[
-					technologiesPermissions[0] ? technologiesPermissions[0].id : null,
-					technologyReviewsPermissions[0] ? technologyReviewsPermissions[0].id : null,
-					uploadsPermissions[0] ? uploadsPermissions[0].id : null,
+					technologiesPermissions[0]?.id || null,
+					technologyReviewsPermissions[0]?.id || null,
+					uploadsPermissions[0]?.id || null,
 					...researcherPermissions,
 					...reviewerPermissions,
-				].filter((e) => e != null),
+				].filter(Boolean),
 			);
 
 		/** DEFAULT_USER ROLE */
@@ -269,11 +266,11 @@ class PermissionSeeder {
 			.permissions()
 			.attach(
 				[
-					technologiesPermissions[0] ? technologiesPermissions[0].id : null,
-					technologyReviewsPermissions[0] ? technologyReviewsPermissions[0].id : null,
-					uploadsPermissions[0] ? uploadsPermissions[0].id : null,
+					technologiesPermissions[0]?.id || null,
+					technologyReviewsPermissions[0]?.id || null,
+					uploadsPermissions[0]?.id || null,
 					...researcherPermissions,
-				].filter((e) => e != null),
+				].filter(Boolean),
 			);
 	}
 }

--- a/packages/api/database/seeds/06_PermissionSeeder.js
+++ b/packages/api/database/seeds/06_PermissionSeeder.js
@@ -15,6 +15,11 @@ class PermissionSeeder {
 	async run() {
 		/* Create All Permissions */
 
+		const permissionsCount = await Permission.getCount();
+		if (permissionsCount > 0) {
+			return;
+		}
+
 		/** ROLE MANAGEMENT */
 		const rolesPermissions = await Permission.createMany([
 			permissions.CREATE_ROLES,

--- a/packages/api/database/seeds/11_DisclaimerSeeder.js
+++ b/packages/api/database/seeds/11_DisclaimerSeeder.js
@@ -13,6 +13,10 @@ const Disclaimer = use('App/Models/Disclaimer');
 const User = use('App/Models/User');
 class DisclaimerSeeder {
 	async run() {
+		const disclaimersCount = await Disclaimer.getCount();
+		if (disclaimersCount > 0) {
+			return;
+		}
 		await Disclaimer.createMany([
 			{
 				description:


### PR DESCRIPTION
## Summary

Resolves #817, Resolves #818  

## Relevant technical choices

- [x] `RoleSeeder.js` => O create e o createMany foi sobrescrito.
- [x] `KnowledgeAreaSeeder.js` => O Seeder apenas checa se existem registros e roda caso não tenha.
- [x]  `TaxonomySeeder.js` => O create e o createMany foi sobrescrito.
- [x]  `TermSeeder.js` => O create e o createMany foi sobrescrito. Foi passado o `slug` para evitar que ele seja re-criado.
- [x]  `PermissionSeeder.js` => O create e o createMany foi sobrescrito. Além disso, ao realizar o attach no `role` foi verificado se a permissão já foi criada.
- [x] `DisclaimerSeeder.js` => O Seeder apenas checa se existem registros e roda caso não tenha.
## QA Steps

Incluir alguma informação nova nos Seeders e rodar o comando `npm run seed:default`.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
