### PR TITLE
Add thumbnail to service

### DIFF
--- a/packages/api/app/Models/Service.js
+++ b/packages/api/app/Models/Service.js
@@ -27,6 +27,10 @@ class Service extends Model {
 		return this.hasMany('App/Models/ServiceOrder');
 	}
 
+	thumbnail() {
+		return this.belongsTo('App/Models/Upload', 'thumbnail_id');
+	}
+
 	/**
 	 * Runs the service query with the provided filters.
 	 *

--- a/packages/api/app/Models/Traits/Params.js
+++ b/packages/api/app/Models/Traits/Params.js
@@ -52,7 +52,7 @@ class Params {
 			institutions: ['users', 'logo'],
 			messages: ['user'],
 			ideas: ['user', 'terms'],
-			services: ['user', 'keywords'],
+			services: ['user', 'keywords', 'thumbnail'],
 			service_orders: ['service', 'user', 'serviceOrderReviews'],
 			service_order_reviews: ['serviceOrder', 'user'],
 			reviewer_technology_history: ['reviewer', 'technology'],

--- a/packages/api/database/factory.js
+++ b/packages/api/database/factory.js
@@ -10,6 +10,7 @@
 */
 /** @type {import('@adonisjs/lucid/src/Factory')} */
 const Factory = use('Factory');
+const Config = use('Adonis/Src/Config');
 const {
 	technologyStatuses,
 	technologyUseStatuses,
@@ -257,7 +258,9 @@ Factory.blueprint('App/Models/TechnologyComment', async (faker, i, data) => {
 
 Factory.blueprint('App/Models/Upload', async (faker, i, data) => {
 	return {
-		filename: `${faker.word({ length: 20 })}.${faker.pickone(['png', 'jpg', 'pdf'])}`,
+		filename: `${faker.word({ length: 20 })}.${faker.pickone(
+			Config.get('upload.allowedFormats'),
+		)}`,
 		...data,
 	};
 });

--- a/packages/api/database/factory.js
+++ b/packages/api/database/factory.js
@@ -254,3 +254,10 @@ Factory.blueprint('App/Models/TechnologyComment', async (faker, i, data) => {
 		...data,
 	};
 });
+
+Factory.blueprint('App/Models/Upload', async (faker, i, data) => {
+	return {
+		filename: `${faker.word({ length: 20 })}.${faker.pickone(['png', 'jpg', 'pdf'])}`,
+		...data,
+	};
+});

--- a/packages/api/database/migrations/1613231368109_service_thumbnail_schema.js
+++ b/packages/api/database/migrations/1613231368109_service_thumbnail_schema.js
@@ -1,0 +1,26 @@
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema');
+
+class ServiceThumbnailSchema extends Schema {
+	up() {
+		this.table('services', (table) => {
+			// alter table
+			table
+				.integer('thumbnail_id')
+				.unsigned()
+				.references('id')
+				.inTable('uploads')
+				.onUpdate('CASCADE')
+				.onDelete('SET NULL');
+		});
+	}
+
+	down() {
+		this.table('services', (table) => {
+			// reverse alternations
+			table.dropForeign(['thumbnail_id']).dropColumn('thumbnail_id');
+		});
+	}
+}
+
+module.exports = ServiceThumbnailSchema;

--- a/packages/api/start/routes/services.js
+++ b/packages/api/start/routes/services.js
@@ -982,6 +982,7 @@ Route.get('services/:id', 'ServiceController.show').middleware(['handleParams'])
  * @apiParam {Number} price Mandatory service price
  * @apiParam {String="hour","day","week","month","unit","other"} measure_unit Mandatory service measure unit
  * @apiParam {String[]|Number[]} keywords Mandatory Keywords ID or Slug Array.
+ * @apiParam {Number} [thumbnail_id] Optional Thumbnail ID file
  * @apiParamExample  {json} Request sample:
  *	{
  *		"name":"Water/earth test service",
@@ -989,7 +990,8 @@ Route.get('services/:id', 'ServiceController.show').middleware(['handleParams'])
  *		"type":"analysis",
  *		"price":1000,
  *		"measure_unit":"hour",
- *		"keywords":[237,238]
+ *		"keywords":[237,238],
+ *		"thumbnail_id": 1
  *	}
  * @apiSuccess {Number} id service ID.
  * @apiSuccess {String} name Service name.

--- a/packages/api/test/functional/service.spec.js
+++ b/packages/api/test/functional/service.spec.js
@@ -128,7 +128,13 @@ test('GET /services/orders/reviews Lists user responsible service order reviews'
 test('POST /services creates a new Service', async ({ client, assert }) => {
 	const { user } = await createUser({ append: { status: 'verified' } });
 
-	const serviceFactory = await Factory.model('App/Models/Service').make();
+	const serviceThumbNail = await Factory.model('App/Models/Upload').create({
+		user_id: user.id,
+	});
+
+	const serviceFactory = await Factory.model('App/Models/Service').make({
+		thumbnail_id: serviceThumbNail.id,
+	});
 
 	const keywordTaxonomy = await Taxonomy.getTaxonomy('KEYWORDS');
 	const keywordTerms = await Factory.model('App/Models/Term').createMany(5);


### PR DESCRIPTION
## Summary

Resolves #815 

## Relevant technical choices

A rota `POST /services` aceita um `thumbnail_id`. Se o thumbnail for criado nessa rota ele é retornado nas rotas de listagem.

## QA Steps

<!-- Passos para testar essa PR (de preferência por um não-desenvolver) -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
