### PR TITLE
Add payment message to service

### DIFF
--- a/packages/api/app/Controllers/Http/ServiceController.js
+++ b/packages/api/app/Controllers/Http/ServiceController.js
@@ -85,6 +85,7 @@ class ServiceController {
 			type,
 			price,
 			measure_unit,
+			payment_message,
 			keywords,
 			thumbnail_id,
 		} = request.all();
@@ -102,6 +103,7 @@ class ServiceController {
 					type,
 					price,
 					measure_unit,
+					payment_message,
 				},
 				trx,
 			);
@@ -204,7 +206,14 @@ class ServiceController {
 	}
 
 	async update({ params, request }) {
-		const data = request.only(['name', 'description', 'type', 'price', 'measure_unit']);
+		const data = request.only([
+			'name',
+			'description',
+			'type',
+			'price',
+			'measure_unit',
+			'payment_message',
+		]);
 		const service = await Service.findOrFail(params.id);
 		service.merge(data);
 		let trx;

--- a/packages/api/database/factory.js
+++ b/packages/api/database/factory.js
@@ -239,6 +239,7 @@ Factory.blueprint('App/Models/Service', async (faker, i, data) => {
 		type: faker.pickone(Object.values(servicesTypes)),
 		price: faker.integer({ min: 10, max: 100000 }),
 		measure_unit: faker.pickone(Object.values(serviceMeasureUnits)),
+		payment_message: faker.sentence({ words: 10 }),
 		...data,
 	};
 });

--- a/packages/api/database/migrations/1614026934264_add_payment_message_to_service_schema.js
+++ b/packages/api/database/migrations/1614026934264_add_payment_message_to_service_schema.js
@@ -1,0 +1,20 @@
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema');
+
+class AddPaymentMessageToServiceSchema extends Schema {
+	up() {
+		this.table('services', (table) => {
+			// alter table
+			table.text('payment_message').after('measure_unit');
+		});
+	}
+
+	down() {
+		this.table('services', (table) => {
+			// reverse alternations
+			table.dropColumn('payment_message');
+		});
+	}
+}
+
+module.exports = AddPaymentMessageToServiceSchema;

--- a/packages/api/start/routes/services.js
+++ b/packages/api/start/routes/services.js
@@ -981,6 +981,7 @@ Route.get('services/:id', 'ServiceController.show').middleware(['handleParams'])
  * @apiParam {String="labor","specialized_technical_work","consulting","analysis","examination","expertise","other"} type Mandatory service type
  * @apiParam {Number} price Mandatory service price
  * @apiParam {String="hour","day","week","month","unit","other"} measure_unit Mandatory service measure unit
+ * @apiParam {String} [payment_message] Optional Payment Message
  * @apiParam {String[]|Number[]} keywords Mandatory Keywords ID or Slug Array.
  * @apiParam {Number} [thumbnail_id] Optional Thumbnail ID file
  * @apiParamExample  {json} Request sample:
@@ -990,6 +991,7 @@ Route.get('services/:id', 'ServiceController.show').middleware(['handleParams'])
  *		"type":"analysis",
  *		"price":1000,
  *		"measure_unit":"hour",
+ *		"payment_message": "For payment use credit card..."
  *		"keywords":[237,238],
  *		"thumbnail_id": 1
  *	}
@@ -999,6 +1001,7 @@ Route.get('services/:id', 'ServiceController.show').middleware(['handleParams'])
  * @apiSuccess {String="labor","specialized_technical_work","consulting","analysis","examination","expertise","other"} type Service type.
  * @apiSuccess {Number} price Service price.
  * @apiSuccess {String="hour","day","week","month","unit","other"} measure_unit Service Measure Unit.
+ * @apiSuccess {String} payment_message Payment Message
  * @apiSuccess {Number} user_id Service Responsible User ID.
  * @apiSuccess {Date} created_at Service Register date
  * @apiSuccess {Date} updated_at Service Update date
@@ -1504,6 +1507,7 @@ Route.post('services/orders/:id/reviews', 'ServiceController.storeServiceOrderRe
  * @apiParam {String="labor","specialized_technical_work","consulting","analysis","examination","expertise","other"} [type] Optional service type
  * @apiParam {Number} [price] Optional service price
  * @apiParam {String="hour","day","week","month","unit","other"} [measure_unit] Optional service measure unit
+ * @apiParam {String} [payment_message] Optional Payment Message
  * @apiParam {String[]|Number[]} [keywords] Optional Keywords ID or Slug Array.
  * @apiParamExample  {json} Request sample:
  *	{
@@ -1512,6 +1516,7 @@ Route.post('services/orders/:id/reviews', 'ServiceController.storeServiceOrderRe
  *		"type":"analysis",
  *		"price":1000,
  *		"measure_unit":"hour",
+ *		"payment_message":"For payments use the credit card"
  *		"keywords":[237,238]
  *	}
  * @apiSuccess {Number} id service ID.
@@ -1520,6 +1525,7 @@ Route.post('services/orders/:id/reviews', 'ServiceController.storeServiceOrderRe
  * @apiSuccess {String="labor","specialized_technical_work","consulting","analysis","examination","expertise","other"} type Service type.
  * @apiSuccess {Number} price Service price.
  * @apiSuccess {String="hour","day","week","month","unit","other"} measure_unit Service Measure Unit.
+ * @apiSuccess {String} payment_message Payment Message
  * @apiSuccess {Number} user_id Service Responsible User ID.
  * @apiSuccess {Date} created_at Service Register date
  * @apiSuccess {Date} updated_at Service Update date


### PR DESCRIPTION
## Summary

Resolves #841 

## Relevant technical choices

### Rotas alteradas

| Description | Method | Route | Body/Query | Auth |
| --- | --- | --- | --- | --- |
|Any user that belongs to institution can create a service |POST| services | name (string),description (string),  type(ENUM('labor', 'specialized_technical_work', 'consulting', 'analysis', 'examination', 'expertise', 'other')), price (number), measure_unit(ENUM('hour', 'day', 'week', 'month', 'unit', 'other')), **payment_message**, keywords (term array id or slug) | Yes: User with institution |
Service responsible can update it |PUT| services/:id | Same POST body | Yes Permission: UPDATE_SERVICE or UPDATE_SERVICES|

## QA Steps

Criar e atualizar um service passando `payment_message` no body.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
