### PR TITLE
Get Hero image through SSR

### DIFF
--- a/packages/web/components/Hero/Hero.js
+++ b/packages/web/components/Hero/Hero.js
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import { TabPanel } from '../Tab';
 
@@ -6,13 +7,7 @@ import { HeroSearch } from './HeroSearch';
 import * as S from './styles';
 import tabs from './tabs';
 
-const Hero = () => {
-	const heroImage = useMemo(() => {
-		const heroImgs = ['1.jpg', '2.jpg', '3.jpg', '4.jpg', '5.jpg', '6.jpg', '7.jpg'];
-		const heroIndexImg = Math.floor(Math.random() * heroImgs.length);
-		return `/hero/${heroImgs[heroIndexImg]}`;
-	}, []);
-
+const Hero = ({ heroImage }) => {
 	return (
 		<S.HeroImage image={heroImage}>
 			<S.TabsWrapper>
@@ -38,6 +33,10 @@ const Hero = () => {
 			</S.TabsWrapper>
 		</S.HeroImage>
 	);
+};
+
+Hero.propTypes = {
+	heroImage: PropTypes.string.isRequired,
 };
 
 export default Hero;

--- a/packages/web/pages/index.js
+++ b/packages/web/pages/index.js
@@ -11,7 +11,7 @@ import { useModal, useTheme } from '../hooks';
 import { internal as internalPages } from '../utils/consts/pages';
 import { getServices, apiPost, apiPut, getTechnologies } from '../services';
 
-const Home = ({ emailConfirmation, changeEmail, technologies, services }) => {
+const Home = ({ emailConfirmation, changeEmail, technologies, services, heroImage }) => {
 	const { colors } = useTheme();
 	const { t } = useTranslation(['common', 'pages']);
 	const { openModal } = useModal();
@@ -31,7 +31,7 @@ const Home = ({ emailConfirmation, changeEmail, technologies, services }) => {
 				description={t('pages:home.description')}
 				keywords={t('pages:home.keywords')}
 			/>
-			<Hero />
+			<Hero heroImage={heroImage} />
 			<ButtonsWrapper>
 				<ButtonsContainer>
 					<Link href={internalPages.announcements} passHref>
@@ -135,11 +135,15 @@ Home.getInitialProps = async ({ req }) => {
 		order: 'DESC',
 	});
 
+	const heroImgs = ['1.jpg', '2.jpg', '3.jpg', '4.jpg', '5.jpg', '6.jpg', '7.jpg'];
+	const heroIndexImg = Math.floor(Math.random() * heroImgs.length);
+
 	return {
 		emailConfirmation,
 		changeEmail,
 		technologies,
 		services,
+		heroImage: `/hero/${heroImgs[heroIndexImg]}`,
 	};
 };
 
@@ -148,6 +152,7 @@ Home.propTypes = {
 	technologies: PropTypes.arrayOf(PropTypes.object),
 	services: PropTypes.arrayOf(PropTypes.object),
 	changeEmail: PropTypes.bool,
+	heroImage: PropTypes.string.isRequired,
 };
 
 Home.defaultProps = {


### PR DESCRIPTION
## Summary

Resolves #1038

## Relevant technical choices

- When home page is rendered through server side we get an alert in console (className mismatch between server and client). This happens due `Math.random` fn used in the React component to get hero image. The consequence of this behavior is that the hero imagem flashes when rendering through SSR.

See [original issue](https://github.com/styled-components/styled-components/issues/3474) for further details

## QA Steps

1. Access home page
2. Hero image shouldn't flash

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
