### PR TITLE
Adds location_type in technology_location

### DIFF
--- a/packages/api/app/Controllers/Http/TechnologyController.js
+++ b/packages/api/app/Controllers/Http/TechnologyController.js
@@ -290,7 +290,24 @@ class TechnologyController {
 			await technology.locations().detach(null, null, trx);
 		}
 
-		await technology.locations().attach(locations, null, trx);
+		const locationsMap = locations.reduce(
+			(obj, currentLocation) => {
+				const { location_id, location_type } = currentLocation;
+				obj.ids.push(location_id);
+				obj.locations[location_id] = location_type;
+				return obj;
+			},
+			{ ids: [], locations: {} },
+		);
+
+		await technology.locations().attach(
+			locationsMap.ids,
+			(row) => {
+				// eslint-disable-next-line no-param-reassign
+				row.location_type = locationsMap.locations[row.location_id];
+			},
+			trx,
+		);
 	}
 
 	/**

--- a/packages/api/app/Models/Technology.js
+++ b/packages/api/app/Models/Technology.js
@@ -210,7 +210,9 @@ class Technology extends Model {
 	}
 
 	locations() {
-		return this.belongsToMany('App/Models/Location').pivotTable('technology_location');
+		return this.belongsToMany('App/Models/Location')
+			.pivotTable('technology_location')
+			.withPivot(['location_type']);
 	}
 
 	async getOwner() {

--- a/packages/api/app/Utils/statuses.js
+++ b/packages/api/app/Utils/statuses.js
@@ -172,6 +172,11 @@ const ordersTypes = {
 	TECHNOLOGY: 'technology',
 };
 
+const technologyLocationsTypes = {
+	WHERE_IS_ALREADY_IMPLEMENTED: 'where_is_already_implemented',
+	WHO_DEVELOP: 'who_develop',
+};
+
 module.exports = {
 	technologyStatuses,
 	reviewerStatuses,
@@ -195,4 +200,5 @@ module.exports = {
 	reviewerTechnologyHistoryStatuses,
 	costsMeasureUnit,
 	ordersTypes,
+	technologyLocationsTypes,
 };

--- a/packages/api/app/Validators/StoreLocation.js
+++ b/packages/api/app/Validators/StoreLocation.js
@@ -3,9 +3,9 @@ const BaseValidator = use('App/Validators/BaseValidator');
 class StoreLocation extends BaseValidator {
 	get rules() {
 		return {
-			place_id: 'required|string|unique:locations',
+			place_id: 'string|unique:locations',
 			address: 'required|string',
-			city_id: 'required|number|exists:cities,id',
+			city_id: 'number|exists:cities,id',
 			lat: 'required|string',
 			lng: 'required|string',
 		};

--- a/packages/api/app/Validators/TechnologyLocation.js
+++ b/packages/api/app/Validators/TechnologyLocation.js
@@ -1,10 +1,14 @@
 const BaseValidator = use('App/Validators/BaseValidator');
+const { technologyLocationsTypes } = require('../Utils');
 
 class TechnologyLocation extends BaseValidator {
 	get rules() {
 		return {
 			locations: 'required|array',
-			'locations.*': 'number|exists:locations,id',
+			'locations.*.location_id': 'required|number|exists:locations,id',
+			'locations.*.location_type': `required|string|in:${Object.values(
+				technologyLocationsTypes,
+			).join()}`,
 		};
 	}
 }

--- a/packages/api/database/migrations/1623709505510_technology_location_type_schema.js
+++ b/packages/api/database/migrations/1623709505510_technology_location_type_schema.js
@@ -1,0 +1,24 @@
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema');
+const { technologyLocationsTypes } = require('../../app/Utils');
+
+class TechnologyLocationTypeSchema extends Schema {
+	up() {
+		this.table('technology_location', (table) => {
+			// alter table
+			table
+				.enu('location_type', Object.values(technologyLocationsTypes))
+				.defaultTo(technologyLocationsTypes.WHERE_IS_ALREADY_IMPLEMENTED)
+				.notNullable();
+		});
+	}
+
+	down() {
+		this.table('technology_location', (table) => {
+			// reverse alternations
+			table.dropColumn('location_type');
+		});
+	}
+}
+
+module.exports = TechnologyLocationTypeSchema;

--- a/packages/api/database/migrations/1623711207596_update_place_id_schema.js
+++ b/packages/api/database/migrations/1623711207596_update_place_id_schema.js
@@ -1,0 +1,25 @@
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema');
+
+class UpdatePlaceIdSchema extends Schema {
+	up() {
+		this.alter('locations', (table) => {
+			table
+				.text('place_id')
+				.nullable()
+				.alter();
+		});
+	}
+
+	down() {
+		this.alter('locations', (table) => {
+			// reverse alternations
+			table
+				.text('place_id')
+				.notNullable()
+				.alter();
+		});
+	}
+}
+
+module.exports = UpdatePlaceIdSchema;

--- a/packages/api/start/routes/technologies.js
+++ b/packages/api/start/routes/technologies.js
@@ -769,9 +769,22 @@ Route.post('technologies/:id/terms', 'TechnologyController.associateTechnologyTe
  *      "Authorization": "Bearer <token>"
  *    }
  * @apiParam (Route Param) {Number} id Mandatory Technology ID
- * @apiParam {String[]|Number[]} locations Loction Array, location IDs
+ * @apiParam {Object[]} locations Loction Array
+ * @apiParam {Number} locations.location_id Location ID, should be exists in Locations schema
+ * @apiParam {String="where_is_already_implemented","who_develop"} locations.location_type Loction Type
  * @apiParamExample  {json} Request sample:
- * 	"locations":[1,2,3,4]
+ * {
+ *	"locations": [
+ *		{
+ *			"location_id":1,
+ *			"location_type": "who_develop"
+ *		},
+ *		{
+ *			"location_id":2,
+ *			"location_type": "where_is_already_implemented"
+ *    }
+ *	]
+ * }
  * @apiSuccess {Object[]} locations Locaction Collection
  * @apiSuccess {Number} locations.id location ID.
  * @apiSuccess {String} locations.place_id location google place ID.
@@ -795,21 +808,8 @@ Route.post('technologies/:id/terms', 'TechnologyController.associateTechnologyTe
  *     "updated_at": "2021-05-29 15:45:15",
  *     "pivot": {
  *       "location_id": 1,
- *       "technology_id": 1
- *     }
- *   },
- *   {
- *     "id": 3,
- *     "place_id": "5e8f46b0b4bf19dddfef28e08cf61cdabc690947",
- *     "address": "982 Artor Pass",
- *     "city_id": 1100122,
- *     "lat": "-71.25248",
- *     "lng": "-79.12979",
- *     "created_at": "2021-05-29 15:45:15",
- *     "updated_at": "2021-05-29 15:45:15",
- *     "pivot": {
- *       "location_id": 3,
- *       "technology_id": 1
+ *       "technology_id": 1,
+ *       "location_type": "where_is_already_implemented"
  *     }
  *   },
  *   {
@@ -823,21 +823,23 @@ Route.post('technologies/:id/terms', 'TechnologyController.associateTechnologyTe
  *     "updated_at": "2021-05-29 15:45:15",
  *     "pivot": {
  *       "location_id": 2,
- *       "technology_id": 1
+ *       "technology_id": 1,
+ *       "location_type": "who_develop"
  *     }
  *   },
  *   {
- *     "id": 4,
- *     "place_id": "7e87099646184a3c82d69f345a373b7af50850f8",
- *     "address": "1923 Ohugab Point",
- *     "city_id": 1100205,
- *     "lat": "30.42617",
- *     "lng": "-148.35236",
+ *     "id": 3,
+ *     "place_id": "5e8f46b0b4bf19dddfef28e08cf61cdabc690947",
+ *     "address": "982 Artor Pass",
+ *     "city_id": 1100122,
+ *     "lat": "-71.25248",
+ *     "lng": "-79.12979",
  *     "created_at": "2021-05-29 15:45:15",
  *     "updated_at": "2021-05-29 15:45:15",
  *     "pivot": {
- *       "location_id": 4,
- *       "technology_id": 1
+ *       "location_id": 3,
+ *       "technology_id": 1,
+ *       "location_type": "where_is_already_implemented"
  *     }
  *   }
  *  ]
@@ -883,7 +885,21 @@ Route.post('technologies/:id/terms', 'TechnologyController.associateTechnologyTe
  *   			]
  * 			}
  *		}
- * @apiErrorExample {json} Validation Error: The locations.[index] should exist in locations
+ * @apiErrorExample {json} Validation Error: The locations.[index].location_id should exist in locations
+ *    HTTP/1.1 400 Bad Request
+ *		{
+ *    		"error": {
+ *        		"error_code": "VALIDATION_ERROR",
+ *        		"message": [
+ *            		{
+ *                		"message": "The locations.0.location_id should exist in locations.",
+ *                		"field": "locations.0.location_id",
+ *                		"validation": "exists"
+ *            		}
+ *        		]
+ *   		}
+ *		}
+ * @apiErrorExample {json} Validation Error: The locations.[index].location_type should fall within defined values of (where_is_already_implemented,who_develop)."
  *    HTTP/1.1 400 Bad Request
  *		{
  *    		"error": {
@@ -891,8 +907,8 @@ Route.post('technologies/:id/terms', 'TechnologyController.associateTechnologyTe
  *        		"message": [
  *            		{
  *                		"message": "The locations.0 should exist in locations.",
- *                		"field": "locations.0",
- *                		"validation": "exists"
+ *                		"field": "locations.0.location_type",
+ *                		"validation": "in"
  *            		}
  *        		]
  *   		}

--- a/packages/api/test/functional/technology.spec.js
+++ b/packages/api/test/functional/technology.spec.js
@@ -26,6 +26,7 @@ const {
 	technologyStatuses,
 	reviewerStatuses,
 	reviewerTechnologyHistoryStatuses,
+	technologyLocationsTypes,
 } = require('../../app/Utils');
 const { prepareTechnology } = require('../../app/Utils/Algolia/indexes/technology');
 const { defaultParams } = require('./params.spec');
@@ -813,7 +814,10 @@ test('POST /technologies/:id/locations unauthorized user trying associates locat
 		city_id: city.id,
 	});
 
-	const locations = locationsInsts.map((location) => location.id);
+	const locations = locationsInsts.map((location) => ({
+		location_id: location.id,
+		location_type: technologyLocationsTypes.WHERE_IS_ALREADY_IMPLEMENTED,
+	}));
 	const response = await client
 		.post(`/technologies/${newTechnology.id}/locations`)
 		.loginVia(loggedUser, 'jwt')
@@ -841,7 +845,10 @@ test('POST /technologies/:id/locations associates locations with own technology.
 		city_id: city.id,
 	});
 
-	const locations = locationsInsts.map((location) => location.id);
+	const locations = locationsInsts.map((location) => ({
+		location_id: location.id,
+		location_type: technologyLocationsTypes.WHERE_IS_ALREADY_IMPLEMENTED,
+	}));
 	const response = await client
 		.post(`/technologies/${newTechnology.id}/locations`)
 		.loginVia(loggedUser, 'jwt')


### PR DESCRIPTION
## Summary

Resolves #1067 

A rota `POST technologies/:id/locations` foi alterada, agora recebe os seguintes parâmetros no body:

```json
 {
	"locations": [
		{
 			"location_id":1, /*Should be exists in locations schema*/
 			"location_type": "who_develop"
 		},
 		{
 			"location_id":2,
 			"location_type": "where_is_already_implemented"
               }
 	]
}
```

## Relevant technical choices

<!-- Descreva as decisões técnicas relevantes -->

## QA Steps

<!-- Passos para testar essa PR (de preferência por um não-desenvolver) -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
