### PR TITLE
Hotfix/api/duplicated location

### DIFF
--- a/packages/api/app/Controllers/Http/TechnologyController.js
+++ b/packages/api/app/Controllers/Http/TechnologyController.js
@@ -469,7 +469,7 @@ class TechnologyController {
 			const { init, commit } = getTransaction();
 			trx = await init();
 
-			await this.syncronizeLocations(trx, locations, technology);
+			await this.syncronizeLocations(trx, locations, technology, true);
 
 			await commit();
 		} catch (error) {


### PR DESCRIPTION
## Summary

Resolves #1073 

## Relevant technical choices

Ao chamar a rota `technologies/:id/locations` a API faz o detach das locations antes de fazer o attach pra evitar as duplicações.

## QA Steps

<!-- Passos para testar essa PR (de preferência por um não-desenvolver) -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code passes the linting.
- [ ] My code has proper inline documentation.
- [ ] I have manually tested this PR.
