### PR TITLE
Use Insitutions slug to open showcase page

### DIFF
--- a/packages/api/app/Models/Institution.js
+++ b/packages/api/app/Models/Institution.js
@@ -29,10 +29,10 @@ class Institution extends Model {
 	}
 
 	/**
-	 * Query scope to get the institution either by id or initials
+	 * Query scope to get the institution either by id or slug
 	 *
 	 * @param {object} query The query object.
-	 * @param {number|string} institution The institution id or initials
+	 * @param {number|string} institution The institution id or slug
 	 * @returns {object}
 	 */
 	static scopeGetInstitution(query, institution) {
@@ -40,7 +40,7 @@ class Institution extends Model {
 			return query.where({ id: institution });
 		}
 
-		return query.where({ initials: institution });
+		return query.where({ slug: institution });
 	}
 
 	/**

--- a/packages/web/screens/Vitrine/Institution/index.js
+++ b/packages/web/screens/Vitrine/Institution/index.js
@@ -6,9 +6,10 @@ import Head from '../../../components/head';
 import { findResultsState, searchStateToURL, urlToSearchState } from '../../../utils/algoliaHelper';
 import { getInstitution } from '../../../services';
 import SolutionList from './SolutionList';
+import ErrorPage from '../../../pages/_error';
 import * as S from './styles';
 
-const InstitutionShowcasePage = ({ initialSearchState, resultsState, institution }) => {
+const InstitutionShowcasePage = ({ initialSearchState, resultsState, institution, notFound }) => {
 	const [searchState, setSearchState] = useState(initialSearchState);
 	const { t } = useTranslation(['pages']);
 
@@ -16,6 +17,10 @@ const InstitutionShowcasePage = ({ initialSearchState, resultsState, institution
 		searchStateToURL(newSearchState);
 		setSearchState(newSearchState);
 	};
+
+	if (notFound) {
+		return <ErrorPage statusCode={404} />;
+	}
 
 	return (
 		<>
@@ -98,13 +103,18 @@ InstitutionShowcasePage.propTypes = {
 		email: PropTypes.string.isRequired,
 		website: PropTypes.string.isRequired,
 	}).isRequired,
+	notFound: PropTypes.bool,
 };
 
-InstitutionShowcasePage.getInitialProps = async ({ query, res, asPath }) => {
+InstitutionShowcasePage.defaultProps = {
+	notFound: false,
+};
+
+InstitutionShowcasePage.getInitialProps = async ({ query, asPath }) => {
 	const institution = await getInstitution(query.institution);
 
 	if (!institution) {
-		return res.writeHead(302, { Location: '/_error.js' }).end();
+		return { notFound: true };
 	}
 
 	const initialSearchState = urlToSearchState(asPath);

--- a/packages/web/screens/Vitrines/HitCard/index.js
+++ b/packages/web/screens/Vitrines/HitCard/index.js
@@ -8,11 +8,11 @@ import { internal as internalPages } from '../../../utils/consts/pages';
 
 import * as S from './styles';
 
-const HitCard = ({ hit: { initials, name, logo, __meta__ } }) => {
+const HitCard = ({ hit: { initials, name, logo, slug, __meta__ } }) => {
 	const { t } = useTranslation(['common']);
 
 	return (
-		<Link href={internalPages.institutionShowcase.replace(':institution', initials)} passHref>
+		<Link href={internalPages.institutionShowcase.replace(':institution', slug)} passHref>
 			<S.Container>
 				<S.Info>
 					<img src={logo?.url || '/add-to-cart-rafiki.svg'} alt="Institution logo" />
@@ -55,6 +55,7 @@ HitCard.propTypes = {
 		logo: {
 			url: PropTypes.string,
 		},
+		slug: PropTypes.string,
 		__meta__: PropTypes.shape({
 			technologies_count: PropTypes.number,
 			services_count: PropTypes.number,


### PR DESCRIPTION
## Summary

Resolves #1037 

## Relevant technical choices

* We have a bug: SSR of `service` index isn't working in institution showcase page. I've tried to fix but it seems to be `react-instantsearch` related. I've opened this issue https://github.com/algolia/react-instantsearch/issues/3075 so we can investigate later.

## QA Steps

1. Open showcases page
2. Click any institution
3. URL must open with slug instead of initials
4. Test an multi initials words institution

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code passes the linting.
- [x] My code has proper inline documentation.
- [x] I have manually tested this PR.
