### PR TITLE
Query Param filterBy

### DIFF
--- a/packages/api/app/Middleware/HandleParam.js
+++ b/packages/api/app/Middleware/HandleParam.js
@@ -9,7 +9,17 @@ class HandleParam {
 	 * @param {Function} next next
 	 */
 	async handle({ request, response }, next) {
-		const data = request.only(['page', 'perPage', 'order', 'orderBy', 'embed', 'ids', 'notIn']);
+		const data = request.only([
+			'page',
+			'perPage',
+			'order',
+			'orderBy',
+			'embed',
+			'ids',
+			'notIn',
+			'filterBy',
+			'filter',
+		]);
 
 		if (data.embed === '') {
 			data.embed = {
@@ -48,6 +58,8 @@ class HandleParam {
 			embed,
 			ids: data.ids.length ? data.ids : defaultListIds,
 			notIn: data.notIn.length ? data.notIn : defaultListIds,
+			filterBy: data.filterBy,
+			filter: data.filter,
 		};
 
 		request.params = params;

--- a/packages/api/app/Models/Traits/Params.js
+++ b/packages/api/app/Models/Traits/Params.js
@@ -199,12 +199,6 @@ class Params {
 			],
 		};
 
-		/* const collumNames = {	
-			institutions: 'name',
-			services: 'name',
-			users: 'first_name',
-		}; */
-
 		Model.queryMacro('withParams', async function withParams(request, options = {}) {
 			const {
 				id,

--- a/packages/api/app/Models/Traits/Params.js
+++ b/packages/api/app/Models/Traits/Params.js
@@ -199,13 +199,34 @@ class Params {
 			],
 		};
 
+		/* const collumNames = {	
+			institutions: 'name',
+			services: 'name',
+			users: 'first_name',
+		}; */
+
 		Model.queryMacro('withParams', async function withParams(request, options = {}) {
-			const { id, embed, page, perPage, order, orderBy, ids, notIn } = request.params;
+			const {
+				id,
+				embed,
+				page,
+				perPage,
+				order,
+				orderBy,
+				ids,
+				notIn,
+				filterBy,
+				filter,
+			} = request.params;
 
 			// eslint-disable-next-line no-underscore-dangle
 			const resource = this._single.table;
 
 			const { filterById = true, skipRelationships = [], skipPagination = false } = options;
+
+			if (filterBy && filter) {
+				this.where(filterBy, 'LIKE', `${filter}%`);
+			}
 
 			if (embed.all) {
 				relationships[resource].map(

--- a/packages/api/app/Models/Traits/Params.js
+++ b/packages/api/app/Models/Traits/Params.js
@@ -225,7 +225,7 @@ class Params {
 			const { filterById = true, skipRelationships = [], skipPagination = false } = options;
 
 			if (filterBy && filter) {
-				this.where(filterBy, 'LIKE', `${filter}%`);
+				this.where(filterBy, 'LIKE', `%${filter}%`);
 			}
 
 			if (embed.all) {

--- a/packages/api/test/functional/params.spec.js
+++ b/packages/api/test/functional/params.spec.js
@@ -6,6 +6,7 @@ const Role = use('App/Models/Role');
 const Permission = use('App/Models/Permission');
 const User = use('App/Models/User');
 const Disclaimer = use('App/Models/Disclaimer');
+const Factory = use('Factory');
 const { createUser } = require('../utils/Suts');
 const {
 	roles: { ADMIN: ADMIN_ROLE },
@@ -507,6 +508,31 @@ test('GET Check translations on General', async ({ client }) => {
 			message: 'O recurso Term não foi encontrado',
 		},
 	});
+});
+
+test('GET using filterBy and filter to filter resources', async ({ client }) => {
+	const { user: loggedUser } = await createUser({ append: { role: ADMIN_ROLE } });
+
+	const filter = {
+		filterBy: 'name',
+		filter: 'Xavier',
+	};
+	const institution = await Factory.model('App/Models/Institution').create({
+		name: "Xavier's School for Gifted Youngsters",
+	});
+
+	const response = await client
+		.get(`/institutions`)
+		.query(filter)
+		.loginVia(loggedUser, 'jwt')
+		.end();
+
+	response.assertStatus(200);
+	response.assertJSONSubset([
+		{
+			name: institution.name,
+		},
+	]);
 });
 
 module.exports.defaultParams = defaultParams;


### PR DESCRIPTION
## Summary

Resolves #1062 

## Relevant technical choices

In all endpoints, was added the query param: `filterBy` and `filter`, ex

`GET institutions?filterBy=name&filter=pw`

`filterBy`: Collumm in database
`filter`: value to search


## QA Steps

<!-- Passos para testar essa PR (de preferência por um não-desenvolver) -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code passes the linting.
- [ ] My code has proper inline documentation.
- [ ] I have manually tested this PR.
